### PR TITLE
Enhance DSP Settings with EQ, Effects, and ReplayGain Controls

### DIFF
--- a/App/BocanApp.swift
+++ b/App/BocanApp.swift
@@ -175,6 +175,7 @@ struct BocanApp: App {
         #endif
     }
 
+    // swiftlint:disable:next function_body_length
     init() {
         Self.registerDefaults()
 
@@ -226,7 +227,12 @@ struct BocanApp: App {
 
         let lvm = LibraryViewModel(database: db, engine: qp, scanner: scanner)
         self.libraryViewModel = lvm
-        self.dspViewModel = DSPViewModel(engine: eng, presetStore: presetStore, queuePlayer: qp)
+        self.dspViewModel = DSPViewModel(
+            engine: eng,
+            presetStore: presetStore,
+            queuePlayer: qp,
+            assignmentRepo: DSPAssignmentRepository(database: db)
+        )
         self.miniPlayerViewModel = MiniPlayerViewModel(nowPlaying: lvm.nowPlaying)
         self.windowMode = WindowModeController()
         self.dockTile = DockTileController()

--- a/App/BocanApp.swift
+++ b/App/BocanApp.swift
@@ -127,7 +127,8 @@ struct BocanApp: App {
                 vm: self.libraryViewModel,
                 windowMode: self.windowMode,
                 lyricsVM: self.lyricsViewModel,
-                visualizerVM: self.visualizerViewModel
+                visualizerVM: self.visualizerViewModel,
+                dspVM: self.dspViewModel
             )
         }
 

--- a/App/BocanApp.swift
+++ b/App/BocanApp.swift
@@ -114,7 +114,7 @@ struct BocanApp: App {
                 visualizerVM: self.visualizerViewModel,
                 routeVM: self.routeViewModel
             )
-            .environmentObject(self.dspViewModel)
+            .environment(self.dspViewModel)
             .environmentObject(self.windowMode)
             .onAppear { self.dockTile.start(observing: self.libraryViewModel.nowPlaying) }
         }
@@ -142,7 +142,7 @@ struct BocanApp: App {
 
         Settings {
             SettingsScene(scrobbleViewModel: self.scrobbleSettingsViewModel)
-                .environmentObject(self.dspViewModel)
+                .environment(self.dspViewModel)
                 .environmentObject(self.libraryViewModel)
                 .environment(\.menuBarExtraEnabled, self.$showMenuBarExtra)
         }

--- a/App/BocanCommands.swift
+++ b/App/BocanCommands.swift
@@ -17,6 +17,7 @@ struct BocanCommands: Commands {
     let windowMode: WindowModeController
     let lyricsVM: LyricsViewModel
     let visualizerVM: VisualizerViewModel
+    let dspVM: DSPViewModel
     @Environment(\.openWindow) private var openWindow
 
     var body: some Commands {
@@ -162,6 +163,13 @@ struct BocanCommands: Commands {
                 self.windowMode.toggleMiniPlayer()
             }
             .keyboardShortcut("m", modifiers: [.command, .option])
+
+            Divider()
+
+            Button("Equaliser & DSP…") {
+                self.dspVM.showDSPPanel = true
+            }
+            .keyboardShortcut(KeyBindings.showEQPanel)
         }
 
         CommandMenu("Track") {

--- a/Modules/AudioEngine/Sources/AudioEngine/DSP/EQUnit.swift
+++ b/Modules/AudioEngine/Sources/AudioEngine/DSP/EQUnit.swift
@@ -1,3 +1,4 @@
+import AudioToolbox
 @preconcurrency import AVFoundation
 import Foundation
 
@@ -43,10 +44,17 @@ public final class EQUnit: @unchecked Sendable {
         }
     }
 
-    /// Reset all bands and global gain to 0 dB.
+    /// Reset all bands and global gain to 0 dB, and flush IIR delay lines.
+    ///
+    /// `AudioUnitReset` zeroes all internal biquad delay buffers.  Call this
+    /// before un-bypassing so the filter re-starts from a known-zero state
+    /// rather than from stale samples held from the previous active period.
     public func reset() {
         self.node.bands.forEach { $0.gain = 0 }
         self.node.globalGain = 0
+        // Flush IIR delay lines — must be called while the unit is still
+        // bypassed (no audio flowing through it) to be a silent operation.
+        AudioUnitReset(self.node.audioUnit, kAudioUnitScope_Global, 0)
     }
 
     /// When `true`, the EQ node is completely bypassed (zero floating-point noise).

--- a/Modules/Persistence/Sources/Persistence/Repositories/DSPAssignmentRepository.swift
+++ b/Modules/Persistence/Sources/Persistence/Repositories/DSPAssignmentRepository.swift
@@ -1,0 +1,113 @@
+import GRDB
+import Observability
+
+/// Read/write per-track and per-album EQ preset assignments.
+///
+/// Rows in `track_dsp_assignments` and `album_dsp_assignments` are optional; absence
+/// means "use the global EQ preset".  The `eq_preset_id` column stores an `EQPreset.id`
+/// string (either `"bocan.*"` for built-ins or a UUID string for user presets).
+///
+/// Priority order at playback time: track assignment → album assignment → global.
+public struct DSPAssignmentRepository: Sendable {
+    // MARK: - Properties
+
+    private let database: Database
+    private let log = AppLogger.make(.persistence)
+
+    // MARK: - Init
+
+    public init(database: Database) {
+        self.database = database
+    }
+
+    // MARK: - Resolution
+
+    /// Returns the highest-priority EQ preset ID for the given track/album pair.
+    ///
+    /// Returns `nil` when neither has a scoped assignment (caller should use global).
+    public func resolvePresetID(trackID: Int64, albumID: Int64?) async throws -> String? {
+        if let id = try await fetchTrackPresetID(trackID: trackID) { return id }
+        if let albumID, let id = try await fetchAlbumPresetID(albumID: albumID) { return id }
+        return nil
+    }
+
+    // MARK: - Track assignments
+
+    /// Returns the EQ preset ID assigned to `trackID`, or `nil` if none is set.
+    public func fetchTrackPresetID(trackID: Int64) async throws -> String? {
+        try await self.database.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: "SELECT eq_preset_id FROM track_dsp_assignments WHERE track_id = ?",
+                arguments: [trackID]
+            )
+            return row?["eq_preset_id"] as? String
+        }
+    }
+
+    /// Assigns `presetID` to `trackID`, replacing any existing assignment.
+    public func setTrackPreset(trackID: Int64, presetID: String) async throws {
+        try await self.database.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO track_dsp_assignments (track_id, eq_preset_id)
+                VALUES (?, ?)
+                ON CONFLICT(track_id) DO UPDATE SET eq_preset_id = excluded.eq_preset_id
+                """,
+                arguments: [trackID, presetID]
+            )
+        }
+        self.log.debug("dsp.track.set", ["trackID": trackID, "presetID": presetID])
+    }
+
+    /// Removes any EQ preset assignment for `trackID`.
+    public func clearTrackPreset(trackID: Int64) async throws {
+        try await self.database.write { db in
+            try db.execute(
+                sql: "DELETE FROM track_dsp_assignments WHERE track_id = ?",
+                arguments: [trackID]
+            )
+        }
+        self.log.debug("dsp.track.clear", ["trackID": trackID])
+    }
+
+    // MARK: - Album assignments
+
+    /// Returns the EQ preset ID assigned to `albumID`, or `nil` if none is set.
+    public func fetchAlbumPresetID(albumID: Int64) async throws -> String? {
+        try await self.database.read { db in
+            let row = try Row.fetchOne(
+                db,
+                sql: "SELECT eq_preset_id FROM album_dsp_assignments WHERE album_id = ?",
+                arguments: [albumID]
+            )
+            return row?["eq_preset_id"] as? String
+        }
+    }
+
+    /// Assigns `presetID` to `albumID`, replacing any existing assignment.
+    public func setAlbumPreset(albumID: Int64, presetID: String) async throws {
+        try await self.database.write { db in
+            try db.execute(
+                sql: """
+                INSERT INTO album_dsp_assignments (album_id, eq_preset_id)
+                VALUES (?, ?)
+                ON CONFLICT(album_id) DO UPDATE SET eq_preset_id = excluded.eq_preset_id
+                """,
+                arguments: [albumID, presetID]
+            )
+        }
+        self.log.debug("dsp.album.set", ["albumID": albumID, "presetID": presetID])
+    }
+
+    /// Removes any EQ preset assignment for `albumID`.
+    public func clearAlbumPreset(albumID: Int64) async throws {
+        try await self.database.write { db in
+            try db.execute(
+                sql: "DELETE FROM album_dsp_assignments WHERE album_id = ?",
+                arguments: [albumID]
+            )
+        }
+        self.log.debug("dsp.album.clear", ["albumID": albumID])
+    }
+}

--- a/Modules/Playback/Sources/Playback/QueuePlayer.swift
+++ b/Modules/Playback/Sources/Playback/QueuePlayer.swift
@@ -50,6 +50,16 @@ public actor QueuePlayer: Transport {
     public nonisolated let currentTrackChanges: AsyncStream<Track?>
     private var currentTrackContinuation: AsyncStream<Track?>.Continuation?
 
+    // MARK: - Track ID changes stream (for EQ scope resolution)
+
+    /// Emits `(trackID, albumID?)` whenever a new track starts loading.
+    ///
+    /// Separate from `currentTrackChanges` so DSP consumers don't compete with
+    /// `NowPlayingViewModel` on the same single-consumer `AsyncStream`.
+    /// Emits `(−1, nil)` when playback stops.
+    public nonisolated let trackIDChanges: AsyncStream<(trackID: Int64, albumID: Int64?)>
+    private var trackIDContinuation: AsyncStream<(trackID: Int64, albumID: Int64?)>.Continuation?
+
     // MARK: - Unavailable items stream
 
     /// Emits the set of queue-item IDs whose backing files are missing.
@@ -119,6 +129,10 @@ public actor QueuePlayer: Transport {
         var trackContinuation: AsyncStream<Track?>.Continuation?
         self.currentTrackChanges = AsyncStream { trackContinuation = $0 }
         self.currentTrackContinuation = trackContinuation
+
+        var trackIDCont: AsyncStream<(trackID: Int64, albumID: Int64?)>.Continuation?
+        self.trackIDChanges = AsyncStream { trackIDCont = $0 }
+        self.trackIDContinuation = trackIDCont
 
         var unavailableContinuation: AsyncStream<Set<QueueItem.ID>>.Continuation?
         self.unavailableItemChanges = AsyncStream { unavailableContinuation = $0 }
@@ -937,10 +951,14 @@ public actor QueuePlayer: Transport {
 
     // MARK: Root-scope fallback
 
-    /// Updates `currentTrack` and broadcasts the change on `currentTrackChanges`.
+    /// Updates `currentTrack` and broadcasts the change on `currentTrackChanges`
+    /// and `trackIDChanges`.
     private func emitCurrentTrack(_ track: Track?) {
         self.currentTrack = track
         self.currentTrackContinuation?.yield(track)
+        let tid: Int64 = track?.id ?? -1
+        let aid: Int64? = track?.albumID
+        self.trackIDContinuation?.yield((trackID: tid, albumID: aid))
     }
 
     /// Finds the library root that contains `fileURLString`, resolves its

--- a/Modules/UI/Sources/UI/AppRoot/NowPlayingStrip.swift
+++ b/Modules/UI/Sources/UI/AppRoot/NowPlayingStrip.swift
@@ -56,6 +56,14 @@ public struct NowPlayingStrip: View {
         .sheet(isPresented: self.$showDSP) {
             DSPSheet(vm: self.dsp)
         }
+        // Allow DSPViewModel.showDSPPanel to open the sheet from menu commands
+        // and keyboard shortcuts that don't have direct access to @State.
+        .onChange(of: self.dsp.showDSPPanel) { _, requested in
+            if requested {
+                self.showDSP = true
+                self.dsp.showDSPPanel = false
+            }
+        }
     }
 
     // MARK: - Sub-views
@@ -222,8 +230,9 @@ public struct NowPlayingStrip: View {
                     .font(.system(size: 15, weight: .medium))
             }
             .buttonStyle(.plain)
+            .keyboardShortcut(KeyBindings.showEQPanel)
             .foregroundStyle(self.showDSP ? Color.accentColor : Color.textPrimary)
-            .help("Equaliser & DSP")
+            .help("Equaliser & DSP (⌘⌥E)")
             .accessibilityLabel("Equaliser & DSP")
 
             Button {

--- a/Modules/UI/Sources/UI/AppRoot/NowPlayingStrip.swift
+++ b/Modules/UI/Sources/UI/AppRoot/NowPlayingStrip.swift
@@ -10,7 +10,7 @@ import SwiftUI
 public struct NowPlayingStrip: View {
     @ObservedObject public var vm: NowPlayingViewModel
     @EnvironmentObject private var library: LibraryViewModel
-    @EnvironmentObject private var dsp: DSPViewModel
+    @Environment(DSPViewModel.self) private var dsp: DSPViewModel
     @EnvironmentObject private var visualizer: VisualizerViewModel
     /// Optional — only the main window injects a `RouteViewModel`. Snapshot
     /// tests and other ad-hoc surfaces can skip it.

--- a/Modules/UI/Sources/UI/Common/KeyBindings.swift
+++ b/Modules/UI/Sources/UI/Common/KeyBindings.swift
@@ -72,6 +72,9 @@ public enum KeyBindings {
     /// `⌘5` — Rate 5 stars.
     public static let rate5 = KeyboardShortcut("5", modifiers: .command)
 
+    /// `⌘⌥E` — Open or close the Equaliser & DSP panel.
+    public static let showEQPanel = KeyboardShortcut("e", modifiers: [.command, .option])
+
     // MARK: - Navigation
 
     /// `⌥⌘→` — Drill into content (album / artist detail).

--- a/Modules/UI/Sources/UI/DSP/DSPSheet.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPSheet.swift
@@ -7,7 +7,7 @@ import SwiftUI
 /// Presented as a sheet from `NowPlayingStrip` when the user taps the EQ button.
 /// Each tab wraps an existing DSP view; the sheet owns no additional state.
 struct DSPSheet: View {
-    @ObservedObject var vm: DSPViewModel
+    @Bindable var vm: DSPViewModel
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {

--- a/Modules/UI/Sources/UI/DSP/DSPView.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPView.swift
@@ -7,7 +7,7 @@ import SwiftUI
 ///
 /// Displayed as a settings panel; composable into a sheet or sidebar pane.
 public struct DSPView: View {
-    @ObservedObject var vm: DSPViewModel
+    @Bindable var vm: DSPViewModel
 
     public init(vm: DSPViewModel) {
         self.vm = vm

--- a/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
@@ -33,6 +33,13 @@ public final class DSPViewModel: ObservableObject {
     /// `true` while ReplayGain analysis is in progress.
     @Published public private(set) var isAnalyzing = false
 
+    /// When set to `true` the DSP/EQ sheet should be presented.
+    ///
+    /// `NowPlayingStrip` observes this and reflects it into its local `showDSP`
+    /// `@State`, so menu commands and keyboard shortcuts that only have access
+    /// to `DSPViewModel` can still open the sheet.
+    @Published public var showDSPPanel = false
+
     /// Which scope the EQ picker targets (Global / This Album / This Track).
     @Published public var eqScope: EQScope = .global
 

--- a/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
@@ -1,8 +1,18 @@
 import AudioEngine
 import Foundation
 import Observability
+import Persistence
 import Playback
 import SwiftUI
+
+// MARK: - EQScope
+
+/// Which scope the EQ preset picker is currently targeting.
+public enum EQScope: String, CaseIterable, Sendable {
+    case global = "Global"
+    case album = "This Album"
+    case track = "This Track"
+}
 
 // MARK: - DSPViewModel
 
@@ -23,28 +33,61 @@ public final class DSPViewModel: ObservableObject {
     /// `true` while ReplayGain analysis is in progress.
     @Published public private(set) var isAnalyzing = false
 
+    /// Which scope the EQ picker targets (Global / This Album / This Track).
+    @Published public var eqScope: EQScope = .global
+
+    /// The `Track.id` of the currently-playing track, updated automatically.
+    @Published public private(set) var currentTrackID: Int64?
+
+    /// The `Album.id` of the currently-playing track's album, updated automatically.
+    @Published public private(set) var currentAlbumID: Int64?
+
+    /// Whether there is a scoped (track or album) EQ assignment active for the current track.
+    @Published public private(set) var hasScopedPreset = false
+
     // MARK: - Dependencies
 
     private let engine: AudioEngine
     public let presetStore: PresetStore
     private let queuePlayer: QueuePlayer?
+    private let assignmentRepo: DSPAssignmentRepository?
     private let log = AppLogger.make(.ui)
+
+    /// Transient override — set from a scoped assignment on track load.
+    /// Not persisted; cleared when the user explicitly picks a preset.
+    private var eqOverridePresetID: String?
 
     // MARK: - Init
 
-    public init(engine: AudioEngine, presetStore: PresetStore = PresetStore(), queuePlayer: QueuePlayer? = nil) {
+    public init(
+        engine: AudioEngine,
+        presetStore: PresetStore = PresetStore(),
+        queuePlayer: QueuePlayer? = nil,
+        assignmentRepo: DSPAssignmentRepository? = nil
+    ) {
         self.engine = engine
         self.presetStore = presetStore
         self.queuePlayer = queuePlayer
+        self.assignmentRepo = assignmentRepo
         self.state = DSPState.load()
         self.presets = presetStore.allPresets
         // Apply persisted state immediately.
         Task { await engine.applyDSPState(self.state) }
+        // Observe track loads to resolve scoped EQ assignments.
+        if let qp = queuePlayer {
+            Task { @MainActor [weak self] in
+                for await change in qp.trackIDChanges {
+                    self?.handleTrackIDChange(trackID: change.trackID, albumID: change.albumID)
+                }
+            }
+        }
     }
 
     // MARK: - Preset actions
 
     public func selectPreset(_ preset: EQPreset) {
+        // Selecting a preset explicitly clears any transient scoped override.
+        self.eqOverridePresetID = nil
         self.state.eqPresetID = preset.id
         self.state.eqEnabled = true
     }
@@ -143,6 +186,62 @@ public final class DSPViewModel: ObservableObject {
         }
     }
 
+    // MARK: - EQ scope assignment
+
+    /// Saves the currently-selected EQ preset as an override for the current scope.
+    ///
+    /// Does nothing when scope is `.global` (global preset is already persisted via UserDefaults)
+    /// or when there is no current track/album for the requested scope.
+    public func saveCurrentScopePreset() async {
+        guard let presetID = self.state.eqPresetID else { return }
+        do {
+            switch self.eqScope {
+            case .global:
+                break
+
+            case .track:
+                guard let tid = self.currentTrackID else { return }
+                try await self.assignmentRepo?.setTrackPreset(trackID: tid, presetID: presetID)
+                self.hasScopedPreset = true
+                self.log.debug("dsp.scope.save.track", ["trackID": tid, "presetID": presetID])
+
+            case .album:
+                guard let aid = self.currentAlbumID else { return }
+                try await self.assignmentRepo?.setAlbumPreset(albumID: aid, presetID: presetID)
+                self.hasScopedPreset = true
+                self.log.debug("dsp.scope.save.album", ["albumID": aid, "presetID": presetID])
+            }
+        } catch {
+            self.log.error("dsp.scope.save.failed", ["error": String(reflecting: error)])
+        }
+    }
+
+    /// Clears the scoped EQ override for the current scope.
+    public func clearCurrentScopePreset() async {
+        do {
+            switch self.eqScope {
+            case .global:
+                break
+
+            case .track:
+                guard let tid = self.currentTrackID else { return }
+                try await self.assignmentRepo?.clearTrackPreset(trackID: tid)
+                self.eqOverridePresetID = nil
+                self.hasScopedPreset = false
+                self.log.debug("dsp.scope.clear.track", ["trackID": tid])
+
+            case .album:
+                guard let aid = self.currentAlbumID else { return }
+                try await self.assignmentRepo?.clearAlbumPreset(albumID: aid)
+                self.eqOverridePresetID = nil
+                self.hasScopedPreset = false
+                self.log.debug("dsp.scope.clear.album", ["albumID": aid])
+            }
+        } catch {
+            self.log.error("dsp.scope.clear.failed", ["error": String(reflecting: error)])
+        }
+    }
+
     // MARK: - ReplayGain analysis
 
     public func analyzeReplayGain(url: URL) async -> ReplayGainResult? {
@@ -160,12 +259,44 @@ public final class DSPViewModel: ObservableObject {
 
     private func pushToEngine() {
         self.state.save()
-        Task { await self.engine.applyDSPState(self.state) }
+        // Use the scoped override if active, otherwise the global preset.
+        var stateToApply = self.state
+        if let override = self.eqOverridePresetID {
+            stateToApply.eqPresetID = override
+        }
+        Task { await self.engine.applyDSPState(stateToApply) }
         // Forward crossfade config to the playback layer so the slider has effect.
         let config = CrossfadeScheduler.Config(
             durationSeconds: self.state.crossfadeSeconds,
             albumGapless: self.state.crossfadeAlbumGapless
         )
         Task { await self.queuePlayer?.setCrossfadeConfig(config) }
+    }
+
+    /// Called from the `trackIDChanges` observation Task whenever a new track loads.
+    private func handleTrackIDChange(trackID: Int64, albumID: Int64?) {
+        self.currentTrackID = trackID >= 0 ? trackID : nil
+        self.currentAlbumID = albumID
+        // Reset scope to global when playback stops.
+        if trackID < 0 {
+            self.eqOverridePresetID = nil
+            self.hasScopedPreset = false
+            return
+        }
+        guard let repo = self.assignmentRepo else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            let resolved = try? await repo.resolvePresetID(trackID: trackID, albumID: albumID)
+            self.eqOverridePresetID = resolved
+            self.hasScopedPreset = resolved != nil
+            if resolved != nil {
+                // Re-push engine state so the override takes effect immediately.
+                self.pushToEngine()
+            }
+            self.log.debug(
+                "dsp.scope.resolved",
+                ["trackID": trackID, "preset": resolved ?? "global"]
+            )
+        }
     }
 }

--- a/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
@@ -1,6 +1,7 @@
 import AudioEngine
 import Foundation
 import Observability
+import Observation
 import Persistence
 import Playback
 import SwiftUI
@@ -21,40 +22,44 @@ public enum EQScope: String, CaseIterable, Sendable {
 /// Owns the `DSPState` snapshot and propagates changes to `AudioEngine` immediately.
 /// All mutations run on `@MainActor`.
 @MainActor
-public final class DSPViewModel: ObservableObject {
-    // MARK: - Published state
+@Observable
+public final class DSPViewModel {
+    // MARK: - State
 
-    @Published public var state: DSPState {
+    /// Current DSP state snapshot; changes are persisted and pushed to the audio engine immediately.
+    public var state: DSPState {
         didSet { self.pushToEngine() }
     }
 
-    @Published public var presets: [EQPreset] = []
+    /// All available EQ presets (built-in + user-saved).
+    public var presets: [EQPreset] = []
 
     /// `true` while ReplayGain analysis is in progress.
-    @Published public private(set) var isAnalyzing = false
+    public private(set) var isAnalyzing = false
 
     /// When set to `true` the DSP/EQ sheet should be presented.
     ///
     /// `NowPlayingStrip` observes this and reflects it into its local `showDSP`
     /// `@State`, so menu commands and keyboard shortcuts that only have access
     /// to `DSPViewModel` can still open the sheet.
-    @Published public var showDSPPanel = false
+    public var showDSPPanel = false
 
     /// Which scope the EQ picker targets (Global / This Album / This Track).
-    @Published public var eqScope: EQScope = .global
+    public var eqScope: EQScope = .global
 
     /// The `Track.id` of the currently-playing track, updated automatically.
-    @Published public private(set) var currentTrackID: Int64?
+    public private(set) var currentTrackID: Int64?
 
     /// The `Album.id` of the currently-playing track's album, updated automatically.
-    @Published public private(set) var currentAlbumID: Int64?
+    public private(set) var currentAlbumID: Int64?
 
     /// Whether there is a scoped (track or album) EQ assignment active for the current track.
-    @Published public private(set) var hasScopedPreset = false
+    public private(set) var hasScopedPreset = false
 
     // MARK: - Dependencies
 
     private let engine: AudioEngine
+    /// The preset store shared between the EQ picker and the preset manager.
     public let presetStore: PresetStore
     private let queuePlayer: QueuePlayer?
     private let assignmentRepo: DSPAssignmentRepository?
@@ -66,6 +71,7 @@ public final class DSPViewModel: ObservableObject {
 
     // MARK: - Init
 
+    /// Creates a `DSPViewModel` wired to the given engine and optional queue player.
     public init(
         engine: AudioEngine,
         presetStore: PresetStore = PresetStore(),
@@ -92,6 +98,7 @@ public final class DSPViewModel: ObservableObject {
 
     // MARK: - Preset actions
 
+    /// Selects an EQ preset, applying it immediately and clearing any transient scope override.
     public func selectPreset(_ preset: EQPreset) {
         // Selecting a preset explicitly clears any transient scoped override.
         self.eqOverridePresetID = nil
@@ -99,6 +106,7 @@ public final class DSPViewModel: ObservableObject {
         self.state.eqEnabled = true
     }
 
+    /// Saves the current EQ band gains as a new named user preset.
     public func saveUserPreset(name: String) {
         guard let id = state.eqPresetID,
               let current = presetStore.preset(forID: id) else { return }
@@ -114,6 +122,7 @@ public final class DSPViewModel: ObservableObject {
         self.state.eqPresetID = newPreset.id
     }
 
+    /// Deletes the user preset with the given ID, falling back to Flat if it was selected.
     public func deleteUserPreset(id: EQPreset.ID) {
         self.presetStore.delete(id: id)
         self.presets = self.presetStore.allPresets
@@ -251,6 +260,7 @@ public final class DSPViewModel: ObservableObject {
 
     // MARK: - ReplayGain analysis
 
+    /// Analyses the audio file at `url` for ReplayGain, returning the result or `nil` on error.
     public func analyzeReplayGain(url: URL) async -> ReplayGainResult? {
         self.isAnalyzing = true
         defer { isAnalyzing = false }

--- a/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
+++ b/Modules/UI/Sources/UI/DSP/DSPViewModel.swift
@@ -112,6 +112,37 @@ public final class DSPViewModel: ObservableObject {
         }
     }
 
+    /// Updates the output gain of the current EQ preset, creating a "Custom" preset
+    /// if the current one is built-in (mirrors the `updateBandGain` pattern).
+    public func updateOutputGain(_ gain: Double) {
+        guard let id = self.state.eqPresetID,
+              let preset = self.presets.first(where: { $0.id == id }) else { return }
+        if preset.isBuiltIn {
+            let customID = "bocan.custom-edit"
+            let custom = EQPreset(
+                id: customID,
+                name: "Custom",
+                bandGainsDB: preset.bandGainsDB,
+                isBuiltIn: false,
+                outputGainDB: gain
+            )
+            self.presetStore.save(custom)
+            self.presets = self.presetStore.allPresets
+            self.state.eqPresetID = customID
+        } else {
+            let updated = EQPreset(
+                id: preset.id,
+                name: preset.name,
+                bandGainsDB: preset.bandGainsDB,
+                isBuiltIn: false,
+                outputGainDB: gain
+            )
+            self.presetStore.save(updated)
+            self.presets = self.presetStore.allPresets
+            self.pushToEngine()
+        }
+    }
+
     // MARK: - ReplayGain analysis
 
     public func analyzeReplayGain(url: URL) async -> ReplayGainResult? {

--- a/Modules/UI/Sources/UI/DSP/EQView.swift
+++ b/Modules/UI/Sources/UI/DSP/EQView.swift
@@ -182,7 +182,7 @@ public struct EQView: View {
     private var outputGainBinding: Binding<Double> {
         Binding(
             get: { self.outputGainValue },
-            set: { _ in } // TODO(phase-10): wire output gain slider to preset mutation
+            set: { self.vm.updateOutputGain($0) }
         )
     }
 

--- a/Modules/UI/Sources/UI/DSP/EQView.swift
+++ b/Modules/UI/Sources/UI/DSP/EQView.swift
@@ -6,7 +6,8 @@ import SwiftUI
 /// 10-band parametric EQ with preset picker, bypass toggle, and A/B compare.
 ///
 /// Sliders are vertical, labelled with ISO centre-frequency names.
-/// The A/B button toggles between the current preset and a flat reference.
+/// The A/B button is press-and-hold: the flat reference is active only while
+/// the button is held down, returning to the active preset on release.
 public struct EQView: View {
     @ObservedObject var vm: DSPViewModel
 
@@ -142,19 +143,31 @@ public struct EQView: View {
     }
 
     private var abButton: some View {
-        Button {
-            self.toggleAB()
-        } label: {
-            Text(self.isABFlat ? "B" : "A")
-                .monospacedDigit()
-                .frame(width: 28, height: 28)
-                .background(self.isABFlat ? Color.accentColor : Color.secondary.opacity(0.2))
-                .foregroundStyle(self.isABFlat ? .white : .primary)
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-        }
-        .buttonStyle(.plain)
-        .accessibilityLabel("A/B compare: toggle between current and flat")
-        .help("Toggle A/B compare (flat reference)")
+        Text(self.isABFlat ? "B" : "A")
+            .monospacedDigit()
+            .frame(width: 28, height: 28)
+            .background(self.isABFlat ? Color.accentColor : Color.secondary.opacity(0.2))
+            .foregroundStyle(self.isABFlat ? .white : .primary)
+            .clipShape(RoundedRectangle(cornerRadius: 6))
+            // Press-and-hold: flat reference is active only while finger/mouse is down.
+            .simultaneousGesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { _ in
+                        guard !self.isABFlat else { return }
+                        self.savedPresetID = self.vm.state.eqPresetID
+                        self.vm.state.eqPresetID = BuiltInPresets.flat.id
+                        self.isABFlat = true
+                    }
+                    .onEnded { _ in
+                        guard self.isABFlat else { return }
+                        self.vm.state.eqPresetID = self.savedPresetID
+                        self.isABFlat = false
+                    }
+            )
+            .accessibilityLabel("A/B compare: hold for flat reference")
+            .accessibilityHint("Hold to preview flat EQ; release to return to active preset")
+            .help("Hold for flat reference — release to return to active preset")
+            .contentShape(Rectangle())
     }
 
     // MARK: - Band sliders
@@ -247,19 +260,6 @@ public struct EQView: View {
 
     private func applyBandChange(index: Int, gain: Double) {
         self.vm.updateBandGain(index: index, gain: gain)
-    }
-
-    private func toggleAB() {
-        if self.isABFlat {
-            // Restore saved preset
-            self.vm.state.eqPresetID = self.savedPresetID
-            self.isABFlat = false
-        } else {
-            // Switch to flat
-            self.savedPresetID = self.vm.state.eqPresetID
-            self.vm.state.eqPresetID = BuiltInPresets.flat.id
-            self.isABFlat = true
-        }
     }
 
     private func freqLabel(_ freq: Float) -> String {

--- a/Modules/UI/Sources/UI/DSP/EQView.swift
+++ b/Modules/UI/Sources/UI/DSP/EQView.swift
@@ -30,6 +30,7 @@ public struct EQView: View {
     public var body: some View {
         VStack(spacing: 12) {
             self.topBar
+            self.scopeRow
             Divider()
             self.bandSliders
             Divider()
@@ -40,6 +41,64 @@ public struct EQView: View {
         .sheet(isPresented: self.$showManagePresets) {
             PresetManagerView(vm: self.vm)
         }
+    }
+
+    // MARK: - Scope row
+
+    private var scopeRow: some View {
+        HStack(spacing: 8) {
+            Text("Scope:")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            Picker("EQ Scope", selection: self.$vm.eqScope) {
+                ForEach(EQScope.allCases, id: \.self) { scope in
+                    Text(scope.rawValue).tag(scope)
+                }
+            }
+            .pickerStyle(.segmented)
+            .accessibilityLabel("EQ scope: Global, This Album, or This Track")
+            .help("Select which scope the EQ preset applies to")
+            .fixedSize()
+            .disabled(
+                (self.vm.eqScope == .track || self.vm.currentTrackID == nil) &&
+                    (self.vm.eqScope == .album || self.vm.currentAlbumID == nil) &&
+                    false
+            )
+
+            Spacer()
+
+            if self.vm.eqScope != .global {
+                if self.vm.hasScopedPreset {
+                    Button("Clear Override") {
+                        Task { await self.vm.clearCurrentScopePreset() }
+                    }
+                    .font(.caption)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.red)
+                    .accessibilityLabel(
+                        "Clear \(self.vm.eqScope.rawValue.lowercased()) EQ override"
+                    )
+                    .help("Remove the EQ preset override for \(self.vm.eqScope.rawValue.lowercased())")
+                }
+                let scopeName = self.vm.eqScope == .track ? "track" : "album"
+                let hasContext = self.vm.eqScope == .track
+                    ? self.vm.currentTrackID != nil
+                    : self.vm.currentAlbumID != nil
+                Button("Save for \(self.vm.eqScope.rawValue)") {
+                    Task { await self.vm.saveCurrentScopePreset() }
+                }
+                .font(.caption)
+                .buttonStyle(.bordered)
+                .disabled(!hasContext || self.vm.state.eqPresetID == nil)
+                .accessibilityLabel("Save current preset for \(self.vm.eqScope.rawValue.lowercased())")
+                .help(
+                    "Pin the current EQ preset to this \(scopeName). " +
+                        "It will be applied automatically when this \(scopeName) plays."
+                )
+            }
+        }
+        .padding(.horizontal, 2)
     }
 
     // MARK: - Top bar

--- a/Modules/UI/Sources/UI/DSP/EQView.swift
+++ b/Modules/UI/Sources/UI/DSP/EQView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// The A/B button is press-and-hold: the flat reference is active only while
 /// the button is held down, returning to the active preset on release.
 public struct EQView: View {
-    @ObservedObject var vm: DSPViewModel
+    @Bindable var vm: DSPViewModel
 
     /// Tracks whether A/B compare mode is showing the flat reference.
     @State private var isABFlat = false

--- a/Modules/UI/Sources/UI/DSP/PresetManagerView.swift
+++ b/Modules/UI/Sources/UI/DSP/PresetManagerView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 /// Manages user-created EQ presets: rename, duplicate, delete.
 /// Built-in presets are shown as read-only references.
 public struct PresetManagerView: View {
-    @ObservedObject var vm: DSPViewModel
+    @Bindable var vm: DSPViewModel
     @Environment(\.dismiss) private var dismiss
 
     @State private var renameID: EQPreset.ID?

--- a/Modules/UI/Sources/UI/DSP/ReplayGainSettingsView.swift
+++ b/Modules/UI/Sources/UI/DSP/ReplayGainSettingsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// Analysis is run in a background task; the view shows progress and result via
 /// `LibraryViewModel.replayGainProgress`.
 public struct ReplayGainSettingsView: View {
-    @ObservedObject var vm: DSPViewModel
+    @Bindable var vm: DSPViewModel
     @EnvironmentObject private var library: LibraryViewModel
 
     @State private var showRecomputeConfirm = false

--- a/Modules/UI/Sources/UI/Settings/DSPSettingsView.swift
+++ b/Modules/UI/Sources/UI/Settings/DSPSettingsView.swift
@@ -2,14 +2,28 @@ import SwiftUI
 
 // MARK: - DSPSettingsView
 
-/// Wraps the full DSP panel in the Settings window.
+/// Full DSP panel embedded in the Settings window.
+///
+/// Mirrors the tabbed layout of `DSPSheet` so users can configure the EQ,
+/// effects, and ReplayGain from the standard Settings window (⌘,) without
+/// needing the Now Playing strip's DSP sheet to be open.
 public struct DSPSettingsView: View {
     @EnvironmentObject private var dsp: DSPViewModel
 
     public init() {}
 
     public var body: some View {
-        DSPView(vm: self.dsp)
-            .navigationTitle("DSP & EQ")
+        TabView {
+            EQView(vm: self.dsp)
+                .tabItem { Label("Equaliser", systemImage: "slider.vertical.3") }
+
+            DSPView(vm: self.dsp)
+                .tabItem { Label("Effects", systemImage: "waveform") }
+
+            ReplayGainSettingsView(vm: self.dsp)
+                .tabItem { Label("ReplayGain", systemImage: "chart.bar.fill") }
+        }
+        .frame(minWidth: 560, minHeight: 480)
+        .navigationTitle("DSP & EQ")
     }
 }

--- a/Modules/UI/Sources/UI/Settings/DSPSettingsView.swift
+++ b/Modules/UI/Sources/UI/Settings/DSPSettingsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 /// effects, and ReplayGain from the standard Settings window (⌘,) without
 /// needing the Now Playing strip's DSP sheet to be open.
 public struct DSPSettingsView: View {
-    @EnvironmentObject private var dsp: DSPViewModel
+    @Environment(DSPViewModel.self) private var dsp: DSPViewModel
 
     public init() {}
 

--- a/Modules/UI/Tests/UITests/SnapshotTests/SnapshotTests.swift
+++ b/Modules/UI/Tests/UITests/SnapshotTests/SnapshotTests.swift
@@ -92,6 +92,7 @@ struct UISnapshotTests {
             let size = CGSize(width: 900, height: Theme.nowPlayingStripHeight)
             let view = NowPlayingStrip(vm: vm)
                 .environmentObject(vizVM)
+                .environment(DSPViewModel(engine: AudioEngine()))
                 .frame(width: size.width, height: size.height)
             assertSnapshot(of: host(view, size: size), as: .image(precision: 0.98), named: "strip-idle-light")
         }
@@ -103,6 +104,7 @@ struct UISnapshotTests {
             let size = CGSize(width: 900, height: Theme.nowPlayingStripHeight)
             let view = NowPlayingStrip(vm: vm)
                 .environmentObject(vizVM)
+                .environment(DSPViewModel(engine: AudioEngine()))
                 .frame(width: size.width, height: size.height)
                 .colorScheme(.dark)
             assertSnapshot(of: host(view, size: size), as: .image(precision: 0.98), named: "strip-idle-dark")
@@ -129,6 +131,7 @@ struct UISnapshotTests {
             let size = CGSize(width: 900, height: Theme.nowPlayingStripHeight)
             let view = NowPlayingStrip(vm: vm)
                 .environmentObject(vizVM)
+                .environment(DSPViewModel(engine: AudioEngine()))
                 .frame(width: size.width, height: size.height)
             assertSnapshot(of: host(view, size: size), as: .image(precision: 0.98), named: "strip-with-track-light")
         }

--- a/Scripts/ExportOptions.plist
+++ b/Scripts/ExportOptions.plist
@@ -10,5 +10,7 @@
     <string>automatic</string>
     <key>stripSwiftSymbols</key>
     <true/>
+    <key>hardened-runtime</key>
+    <true/>
 </dict>
 </plist>


### PR DESCRIPTION
This pull request introduces per-track and per-album EQ preset assignment support, improves DSP/EQ UI integration, and enhances the underlying audio and UI architecture for better state management and user experience. The main changes include a new repository for EQ assignments, updates to the DSP view model for scope-aware preset selection, keyboard shortcuts and menu integration for the EQ panel, and improvements to the audio engine and UI to support these features.

**DSP/EQ Assignment and State Management:**

* Added the new `DSPAssignmentRepository` for reading and writing per-track and per-album EQ preset assignments, including methods for resolving, setting, and clearing assignments.
* Updated `DSPViewModel` to support EQ scope (global/album/track), observe track changes, resolve scoped EQ assignments, and expose new observable properties for UI binding. Switched to Swift's `@Observable` macro for more granular and efficient UI updates. [[1]](diffhunk://#diff-439b5eca469f49d603c83d17886bbcb698e0407a735843408f264fbd88e0d4bdR4-R109) [[2]](diffhunk://#diff-439b5eca469f49d603c83d17886bbcb698e0407a735843408f264fbd88e0d4bdR125)
* Modified `BocanApp.swift` to inject `DSPViewModel` using `.environment` instead of `.environmentObject`, and to initialize it with the new assignment repository. [[1]](diffhunk://#diff-9745a5fe89546d95dc0ddf32a3109ac8f9263300ab1b4a8e3405526fd838df48L117-R117) [[2]](diffhunk://#diff-9745a5fe89546d95dc0ddf32a3109ac8f9263300ab1b4a8e3405526fd838df48L144-R145) [[3]](diffhunk://#diff-9745a5fe89546d95dc0ddf32a3109ac8f9263300ab1b4a8e3405526fd838df48L229-R236)

**Audio Engine and Playback Integration:**

* Extended `QueuePlayer` with a new `trackIDChanges` async stream that emits track and album IDs on playback changes, enabling DSP consumers to resolve EQ scope without interfering with other consumers. [[1]](diffhunk://#diff-fbe5c83f146f86499e6797c8832bb087a4dc00a51d1c99b450eb09b45528e0c5R53-R62) [[2]](diffhunk://#diff-fbe5c83f146f86499e6797c8832bb087a4dc00a51d1c99b450eb09b45528e0c5R133-R136) [[3]](diffhunk://#diff-fbe5c83f146f86499e6797c8832bb087a4dc00a51d1c99b450eb09b45528e0c5L940-R961)
* Enhanced `EQUnit.reset()` to flush IIR delay lines using `AudioUnitReset`, ensuring the EQ filter restarts from a clean state when un-bypassing. [[1]](diffhunk://#diff-ac4cd088af0164ef86cfd99324e45cff40877d7d6cc5cb0c32e932e29f12ef8eL46-R57) [[2]](diffhunk://#diff-ac4cd088af0164ef86cfd99324e45cff40877d7d6cc5cb0c32e932e29f12ef8eR1)

**UI and User Experience Improvements:**

* Updated `NowPlayingStrip` and related DSP/EQ views to use the new environment-based DSP view model, react to global show/hide requests for the DSP panel, and display a keyboard shortcut in tooltips. [[1]](diffhunk://#diff-ae99c07ec25edbdcc88d583e42aeb569de4905b1733d0bdd5a85bbfe14851a5bL13-R13) [[2]](diffhunk://#diff-ae99c07ec25edbdcc88d583e42aeb569de4905b1733d0bdd5a85bbfe14851a5bR59-R66) [[3]](diffhunk://#diff-ae99c07ec25edbdcc88d583e42aeb569de4905b1733d0bdd5a85bbfe14851a5bR233-R235)
* Added a new keyboard shortcut (`⌘⌥E`) and menu command for opening the Equaliser & DSP panel, reflected in both the menu and UI help text. [[1]](diffhunk://#diff-1e0e2c71efbd1de213092bdca9a778dc6994393748514e519ab75058fa7f8612R75-R77) [[2]](diffhunk://#diff-6ab35ce334accf07eb9dede189d7a125a8f1d84e9154955bebf87d6b77bf2568R166-R172)
* Updated DSP/EQ view initializers to use `@Bindable` for improved SwiftUI compatibility. [[1]](diffhunk://#diff-3beab6ceecfed23e13cabd3c18b58ebecce50015307ad4f1973da95a829c4612L10-R10) [[2]](diffhunk://#diff-00a0d796137ac0641406dec7317ad4269ec57912bbb016fcc3313f34ef661864L10-R10)
* Passed the DSP view model explicitly to `BocanCommands` for menu integration. [[1]](diffhunk://#diff-9745a5fe89546d95dc0ddf32a3109ac8f9263300ab1b4a8e3405526fd838df48L130-R131) [[2]](diffhunk://#diff-6ab35ce334accf07eb9dede189d7a125a8f1d84e9154955bebf87d6b77bf2568R20)

These changes collectively enable users to assign EQ presets at the track or album level, have the correct preset automatically applied during playback, and access the DSP/EQ panel more intuitively via the UI and keyboard.