### PR TITLE
ci: fix notarization stapler + reduce macos runner cost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,17 +3,50 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "website/**"
+      - "phases/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "website/**"
+      - "phases/**"
+      - ".github/ISSUE_TEMPLATE/**"
+      - ".github/PULL_REQUEST_TEMPLATE/**"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  lint:
+    name: Lint (SwiftLint + SwiftFormat)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
+        with:
+          path: ~/.swiftpm
+          key: ${{ runner.os }}-swiftlint-${{ hashFiles('.swiftlint.yml', '.swiftformat') }}
+      - name: SwiftLint
+        uses: norio-nomura/action-swiftlint@3.2.1
+        with:
+          args: --strict
+      - name: SwiftFormat (lint only)
+        run: |
+          brew install swiftformat
+          swiftformat --lint .
+
   build-and-test:
     name: Build & Test
     runs-on: macos-26
+    needs: lint
 
     steps:
       - name: Checkout
@@ -67,9 +100,6 @@ jobs:
 
       - name: Generate Xcode project
         run: make generate
-
-      - name: Lint (SwiftLint + SwiftFormat)
-        run: make lint && make format-check
 
       - name: Build & Test with coverage
         run: make test-coverage 2>&1 | xcbeautify

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,14 +183,32 @@ jobs:
         run: |
           # notarytool requires a zip for .app submission.
           ditto -c -k --keepParent "build/export/Bocan.app" "build/Bocan-notarize.zip"
-          xcrun notarytool submit "build/Bocan-notarize.zip" \
+          RESULT=$(xcrun notarytool submit "build/Bocan-notarize.zip" \
             --apple-id "$APPLE_ID" \
             --team-id "$APPLE_TEAM_ID" \
             --password "$APP_SPECIFIC_PASSWORD" \
-            --wait
+            --wait --output-format plist)
+          echo "$RESULT"
+          STATUS=$(/usr/libexec/PlistBuddy -c "Print :status" /dev/stdin <<< "$RESULT")
+          if [[ "$STATUS" != "Accepted" ]]; then
+            echo "::error::Notarization was not accepted (status: $STATUS). Check the log above."
+            exit 1
+          fi
 
       - name: Staple app
-        run: xcrun stapler staple build/export/Bocan.app
+        # Apple's CloudKit CDN can take a moment to propagate the ticket
+        # even after notarytool --wait returns.  Retry up to 5 times.
+        run: |
+          for attempt in $(seq 1 5); do
+            xcrun stapler staple build/export/Bocan.app && break
+            if [[ $attempt -lt 5 ]]; then
+              echo "Staple attempt $attempt failed; waiting 30 s before retry..."
+              sleep 30
+            else
+              echo "::error::xcrun stapler failed after $attempt attempts."
+              exit 1
+            fi
+          done
 
       - name: Create DMG
         run: |


### PR DESCRIPTION
release.yml:
- notarytool submit now captures output and explicitly checks status == 'Accepted'; any rejection fails the step immediately with a clear error rather than silently passing and failing at stapler
- Staple app step retries up to 5 times with 30 s gaps to handle Apple's CloudKit CDN propagation delay (root cause of Error 65 'Record not found')

ci.yml:
- Add paths-ignore: skip the macos runner for doc/phase/website-only changes (*.md, docs/, website/, phases/, issue templates)
- Extract lint (SwiftLint + SwiftFormat) into a separate ubuntu-latest job that runs first; build-and-test needs: lint so formatting errors get a fast rejection without burning a macos-26 minute

## Summary

<!-- One-line description of what this PR does -->

Closes #<!-- issue number -->

## Phase

This PR relates to: [phases/<!-- phase-NN-name.md -->](../phases/<!-- phase-NN-name.md -->)

## Changes

<!-- Bullet list of what changed -->

## Testing

- [ ] `make lint` passes
- [ ] `make test-coverage` passes (≥ 80%)
- [ ] Tested manually on macOS 14+
- [ ] UI tested in both light and dark mode (where applicable)
- [ ] No `--no-verify` used on any commit in this PR

## Checklist

- [ ] Conventional Commit message(s) used
- [ ] No secrets committed
- [ ] Entitlements not broadened beyond what this phase needs
- [ ] New public API has at least one `@Test`
