### PR TITLE
fix(ui): replace hard-coded Text literals with L10n.string() for prop…

### DIFF
--- a/Modules/UI/Sources/UI/DSP/ReplayGainSettingsView.swift
+++ b/Modules/UI/Sources/UI/DSP/ReplayGainSettingsView.swift
@@ -37,7 +37,7 @@ public struct ReplayGainSettingsView: View {
             }
             Button("Cancel", role: .cancel) {}
         } message: {
-            Text("This will re-analyse every track in the library. It may take several minutes.")
+            Text(L10n.string("This will re-analyse every track in the library. It may take several minutes."))
         }
     }
 
@@ -46,10 +46,10 @@ public struct ReplayGainSettingsView: View {
     private var modeSection: some View {
         Section("Playback Mode") {
             Picker("ReplayGain", selection: self.$vm.state.replayGainMode) {
-                Text("Off").tag(ReplayGainMode.off)
-                Text("Track Gain").tag(ReplayGainMode.track)
-                Text("Album Gain").tag(ReplayGainMode.album)
-                Text("Auto").tag(ReplayGainMode.auto)
+                Text(L10n.string("Off")).tag(ReplayGainMode.off)
+                Text(L10n.string("Track Gain")).tag(ReplayGainMode.track)
+                Text(L10n.string("Album Gain")).tag(ReplayGainMode.album)
+                Text(L10n.string("Auto")).tag(ReplayGainMode.auto)
             }
             .pickerStyle(.segmented)
             .accessibilityLabel("ReplayGain mode")
@@ -72,7 +72,7 @@ public struct ReplayGainSettingsView: View {
                         .frame(width: 52, alignment: .trailing)
                 }
             }
-            Text("Applied on top of the resolved ReplayGain value. A clipping guard prevents the output peak from exceeding −0.5 dBFS.")
+            Text(L10n.string("Applied on top of the resolved ReplayGain value. A clipping guard prevents the output peak from exceeding −0.5 dBFS."))
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -91,7 +91,7 @@ public struct ReplayGainSettingsView: View {
     private var analysisButtons: some View {
         Group {
             HStack {
-                Text("Compute missing ReplayGain values")
+                Text(L10n.string("Compute missing ReplayGain values"))
                 Spacer()
                 Button("Compute Missing") {
                     Task { await self.library.computeMissingReplayGain() }
@@ -126,12 +126,12 @@ public struct ReplayGainSettingsView: View {
                         value: Double(progress.done),
                         total: Double(progress.total)
                     )
-                    Text("\(progress.done) / \(progress.total)")
+                    Text(L10n.string("\(progress.done) / \(progress.total)"))
                         .font(.caption.monospacedDigit())
                         .foregroundStyle(.secondary)
                         .frame(width: 60, alignment: .trailing)
                 }
-                Text("Analysing\u{2026}")
+                Text(L10n.string("Analysing\u{2026}"))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }

--- a/Modules/UI/Sources/UI/Settings/AdvancedSettingsView.swift
+++ b/Modules/UI/Sources/UI/Settings/AdvancedSettingsView.swift
@@ -30,17 +30,17 @@ public struct AdvancedSettingsView: View {
                     if self.backupVM.isBackingUp {
                         HStack(spacing: 6) {
                             ProgressView().controlSize(.small)
-                            Text("Backing up…")
+                            Text(L10n.string("Backing up…"))
                         }
                     } else {
-                        Text("Back Up Now")
+                        Text(L10n.string("Back Up Now"))
                     }
                 }
                 .disabled(!self.backupVM.iCloudAvailable || self.backupVM.isBackingUp)
                 .help("Writes a consistent snapshot using the SQLite backup API.")
 
                 if !self.backupVM.iCloudAvailable {
-                    Text("iCloud Drive is not available on this Mac. Sign in to iCloud in System Settings to enable backups.")
+                    Text(L10n.string("iCloud Drive is not available on this Mac. Sign in to iCloud in System Settings to enable backups."))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
@@ -76,10 +76,10 @@ public struct AdvancedSettingsView: View {
                         if self.backupVM.isLocalBackingUp {
                             HStack(spacing: 6) {
                                 ProgressView().controlSize(.small)
-                                Text("Backing up…")
+                                Text(L10n.string("Backing up…"))
                             }
                         } else {
-                            Text("Back Up Now")
+                            Text(L10n.string("Back Up Now"))
                         }
                     }
                     .disabled(self.backupVM.isLocalBackingUp)
@@ -102,10 +102,10 @@ public struct AdvancedSettingsView: View {
 
             Section("Logging") {
                 Picker("Log level", selection: self.$logLevel) {
-                    Text("Debug").tag("debug")
-                    Text("Info").tag("info")
-                    Text("Warning").tag("warning")
-                    Text("Error").tag("error")
+                    Text(L10n.string("Debug")).tag("debug")
+                    Text(L10n.string("Info")).tag("info")
+                    Text(L10n.string("Warning")).tag("warning")
+                    Text(L10n.string("Error")).tag("error")
                 }
             }
 
@@ -134,7 +134,7 @@ public struct AdvancedSettingsView: View {
                     Button("Reset", role: .destructive) { self.resetPreferences() }
                     Button("Cancel", role: .cancel) {}
                 } message: {
-                    Text("This cannot be undone. Bòcan will restart with default settings.")
+                    Text(L10n.string("This cannot be undone. Bòcan will restart with default settings."))
                 }
 
                 Button("Export Diagnostics…") {

--- a/Modules/UI/Sources/UI/Settings/SubsonicSettingsView.swift
+++ b/Modules/UI/Sources/UI/Settings/SubsonicSettingsView.swift
@@ -175,10 +175,10 @@ private struct SubsonicEmptyState: View {
             Image(systemName: "server.rack")
                 .font(.system(size: 48, weight: .light))
                 .foregroundStyle(.secondary)
-            Text("No Sources Configured")
+            Text(L10n.string("No Sources Configured"))
                 .font(.title3)
-            Text("Add a Subsonic, Navidrome, or other compatible server "
-                + "to stream your remote music library.")
+            Text(L10n.string("Add a Subsonic, Navidrome, or other compatible server "
+                + "to stream your remote music library."))
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -221,9 +221,9 @@ private struct SubsonicServerEditorView: View {
 
             Section("Authentication") {
                 Picker("Method", selection: self.$vm.editor.authKind) {
-                    Text("Token + Password (Subsonic / Navidrome)")
+                    Text(L10n.string("Token + Password (Subsonic / Navidrome)"))
                         .tag(SubsonicAuthKind.tokenSalt)
-                    Text("API Key (OpenSubsonic)")
+                    Text(L10n.string("API Key (OpenSubsonic)"))
                         .tag(SubsonicAuthKind.apiKey)
                 }
                 .pickerStyle(.menu)
@@ -251,15 +251,15 @@ private struct SubsonicServerEditorView: View {
 
             Section("Streaming") {
                 Picker("Maximum Bitrate", selection: self.$vm.editor.bitrateKind) {
-                    Text("Original quality").tag(SubsonicSettingsViewModel.BitrateKind.original)
-                    Text("Cap at…").tag(SubsonicSettingsViewModel.BitrateKind.kbps)
+                    Text(L10n.string("Original quality")).tag(SubsonicSettingsViewModel.BitrateKind.original)
+                    Text(L10n.string("Cap at…")).tag(SubsonicSettingsViewModel.BitrateKind.kbps)
                 }
                 .pickerStyle(.segmented)
 
                 if self.vm.editor.bitrateKind == .kbps {
                     Picker("Bitrate", selection: self.$vm.editor.bitrateKbps) {
                         ForEach([96, 128, 192, 256, 320], id: \.self) { kbps in
-                            Text("\(kbps) kbps").tag(kbps)
+                            Text(L10n.string("\(kbps) kbps")).tag(kbps)
                         }
                     }
                     .pickerStyle(.menu)
@@ -359,7 +359,7 @@ private struct TestResultBlock: View {
                 Label(self.headline(for: caps), systemImage: "checkmark.seal.fill")
                     .foregroundStyle(.green)
                 if !self.extensions(from: caps).isEmpty {
-                    Text("Advertised extensions: " + self.extensions(from: caps).joined(separator: ", "))
+                    Text(L10n.string("Advertised extensions: \(self.extensions(from: caps).joined(separator: ", "))"))
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }


### PR DESCRIPTION
## Problem
Bare Text("...") in SPM modules resolves against Bundle.main instead of the module's String Catalog, causing strings to appear untranslated in non-English locales.

## Changes
Wrapped hard-coded Text() literals with L10n.string() in 3 files:
- AdvancedSettingsView.swift (10 strings)
- ReplayGainSettingsView.swift (9 strings)  
- SubsonicSettingsView.swift (8 strings)

Total: 27 strings fixed

## Related Issue
Closes #314