### PR TITLE
fix(ui): restore artist row navigation

### DIFF
--- a/Modules/UI/Sources/UI/Browse/ArtistsView.swift
+++ b/Modules/UI/Sources/UI/Browse/ArtistsView.swift
@@ -390,6 +390,7 @@ public struct ArtistsView: View {
                     .accessibilityHidden(true)
             }
             .contentShape(Rectangle())
+            .tag(artist.id)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(artist.name)
             .contextMenu {

--- a/Modules/UI/Tests/UITests/ViewModelTests/ArtistsScrollRestoreConventionTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/ArtistsScrollRestoreConventionTests.swift
@@ -19,6 +19,15 @@ struct ArtistsScrollRestoreConventionTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
+    @Test("Artist rows provide selection tags so clicks can navigate")
+    func artistRowsProvideSelectionTags() throws {
+        let source = try self.artistsSource()
+        #expect(
+            source.contains(".tag(artist.id)"),
+            "List(selection:) only updates selectedArtistID when each artist row has a matching tag"
+        )
+    }
+
     @Test("The list snapshots the visited artist and re-centers it on return (#349)")
     func listRestoresScrollPosition() throws {
         let source = try self.artistsSource()


### PR DESCRIPTION
## Summary

- tag each local artist row with its database ID so `List(selection:)` updates `selectedArtistID`
- add a regression convention test that guards the selection tag

## Root cause

`ArtistsView` declared a selection binding and navigated from its `onChange`, but its rows had no `.tag(...)`. On macOS, clicking a row therefore focused the list without changing the selection, so the navigation handler never ran.

This aligns the local artist list with the tagged selection lists already used by the sidebar, settings, and Subsonic genres.

## User impact

Clicking an artist in Local Library > Artists now opens that artist's albums and songs. Navigation from the now-playing strip was already functional because it passes the artist ID directly.

## Validation

- reproduced on Bòcan 2.1.0 with a 3,079-track local library
- focused regression test passes: `ArtistsScrollRestoreConventionTests/artistRowsProvideSelectionTags`
- `make lint` passes with 0 violations across 573 files
- `make format-check` passes with 0 files requiring formatting
- unsigned Debug build succeeds: `make build XCB_OVERRIDE=CODE_SIGNING_ALLOWED=NO`

The complete UI suite starts successfully but an existing `PhoneSyncSnapshotTests` case crashes in Core Image (`CIAreaAverage`) under Xcode 26.6. The focused regression test and application build both pass.

Relevant design spec: `docs/design-spec/phase-04-library-ui.md`
