### PR TITLE
Fix playback progress resetting on pause

### DIFF
--- a/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
@@ -551,31 +551,6 @@ public final class NowPlayingViewModel {
             }
         }
     }
-
-    private func startPollingPosition() {
-        self.stopPollingPosition()
-        self.positionTask = Task { [weak self] in
-            while !Task.isCancelled {
-                guard let self else { break }
-                let pos = await engine.currentTime
-                let dur = await engine.duration
-                // Cancellation can happen while either actor read is suspended.
-                // Do not let that stale tick overwrite the final position captured
-                // by the paused-state handler.
-                guard !Task.isCancelled else { break }
-                await MainActor.run {
-                    self.position = pos
-                    if dur > 0 { self.duration = dur }
-                }
-                try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 s
-            }
-        }
-    }
-
-    private func stopPollingPosition() {
-        self.positionTask?.cancel()
-        self.positionTask = nil
-    }
 }
 
 // MARK: - NowPlayingViewModel podcast transport
@@ -611,6 +586,31 @@ extension NowPlayingViewModel {
 }
 
 private extension NowPlayingViewModel {
+    func startPollingPosition() {
+        self.stopPollingPosition()
+        self.positionTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { break }
+                let pos = await engine.currentTime
+                let dur = await engine.duration
+                // Cancellation can happen while either actor read is suspended.
+                // Do not let that stale tick overwrite the final position captured
+                // by the paused-state handler.
+                guard !Task.isCancelled else { break }
+                await MainActor.run {
+                    self.position = pos
+                    if dur > 0 { self.duration = dur }
+                }
+                try? await Task.sleep(nanoseconds: 500_000_000) // 0.5 s
+            }
+        }
+    }
+
+    func stopPollingPosition() {
+        self.positionTask?.cancel()
+        self.positionTask = nil
+    }
+
     /// Fills podcast-specific now-playing state when the current queue item is a podcast episode.
     func applyPodcastItem(feedURL: URL, episodeGUID: String) async {
         self.isPodcast = true

--- a/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
@@ -522,6 +522,11 @@ public final class NowPlayingViewModel {
                     self.isPlaying = false
                     self.isPaused = true
                     self.stopPollingPosition()
+                    // The 500 ms polling cadence can leave `position` stale (or
+                    // still at zero for a quick play/pause). Capture the engine's
+                    // banked pause position so the scrubber freezes exactly where
+                    // playback will resume.
+                    self.position = await self.engine.currentTime
 
                 // `.failed` shares the not-playing teardown; the engine has already
                 // stopped and frozen the position, so we only add the user-facing alert.
@@ -554,6 +559,10 @@ public final class NowPlayingViewModel {
                 guard let self else { break }
                 let pos = await engine.currentTime
                 let dur = await engine.duration
+                // Cancellation can happen while either actor read is suspended.
+                // Do not let that stale tick overwrite the final position captured
+                // by the paused-state handler.
+                guard !Task.isCancelled else { break }
                 await MainActor.run {
                     self.position = pos
                     if dur > 0 { self.duration = dur }

--- a/Modules/UI/Tests/UITests/ViewModelTests/NowPlayingViewModelTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/NowPlayingViewModelTests.swift
@@ -192,6 +192,25 @@ struct NowPlayingViewModelTests {
         #expect(engine.pauseCallCount == 1)
     }
 
+    @Test("pausing captures the engine position between polling ticks")
+    func pauseCapturesFinalPosition() async throws {
+        let engine = MockTransport()
+        let db = try await makeDatabase()
+        let vm = NowPlayingViewModel(engine: engine, database: db)
+        engine.storedCurrentTime = 87.25
+
+        // No playing event is needed: this specifically covers pausing before
+        // the periodic UI poll has published its first value.
+        engine.emit(.paused)
+        for _ in 0 ..< 100 {
+            if vm.isPaused, vm.position == 87.25 { break }
+            await Task.yield()
+        }
+
+        #expect(vm.isPaused)
+        #expect(vm.position == 87.25)
+    }
+
     @Test("scrub dispatches seek to engine")
     func scrubDispatchesSsek() async throws {
         let engine = MockTransport()


### PR DESCRIPTION
## Summary

- capture the engine's final playback position when playback enters the paused state
- prevent a cancelled position-polling task from publishing a stale value
- add a regression test for pausing between periodic UI position updates

## Root cause

The now-playing view model stopped its 500 ms position polling task as soon as it received the paused state, without first reading the position banked by the audio engine. A quick pause, or a pause between polling ticks, could therefore leave the scrubber at an old value (including zero) even though playback later resumed from the correct engine position. A polling task cancelled while suspended could also publish one final stale update.

## User impact

The scrubber and elapsed-time display now remain at the actual paused position and continue from that point when playback resumes.

## Validation

- `swift test --filter pauseCapturesFinalPosition` — passed
- `git diff --check` — passed
- `make test-ui` — the relevant view-model tests passed, but the full run terminated in an unrelated existing Phone Sync snapshot test with a CoreImage `NSInvalidArgumentException`
