### PR TITLE
fix(ui): navigate from artist rows directly

### DIFF
--- a/Modules/UI/Sources/UI/Browse/ArtistsView.swift
+++ b/Modules/UI/Sources/UI/Browse/ArtistsView.swift
@@ -351,48 +351,53 @@ public struct ArtistsView: View {
     }
 
     private var artistListContent: some View {
-        List(self.vm.artists, id: \.id, selection: self.$vm.selectedArtistID) { artist in
-            HStack(spacing: 10) {
-                // Avatar circle
-                ZStack {
-                    Circle()
-                        .fill(Color.accentColor.opacity(0.15))
-                        .frame(width: 36, height: 36)
-                    Image(systemName: "music.mic")
-                        .font(.system(size: 14, weight: .medium))
-                        .foregroundStyle(Color.accentColor)
-                }
-                .accessibilityHidden(true)
+        List(self.vm.artists, id: \.id) { artist in
+            Button {
+                self.openArtist(artist)
+            } label: {
+                HStack(spacing: 10) {
+                    // Avatar circle
+                    ZStack {
+                        Circle()
+                            .fill(Color.accentColor.opacity(0.15))
+                            .frame(width: 36, height: 36)
+                        Image(systemName: "music.mic")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(Color.accentColor)
+                    }
+                    .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(artist.name)
-                        .font(Typography.body)
-                        .foregroundStyle(Color.textPrimary)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(artist.name)
+                            .font(Typography.body)
+                            .foregroundStyle(Color.textPrimary)
 
-                    if let id = artist.id {
-                        let albumCount = self.vm.albumCounts[id] ?? 0
-                        let trackCount = self.vm.trackCounts[id] ?? 0
-                        if albumCount > 0 || trackCount > 0 {
-                            let albumPart = L10n.string("\(albumCount) albums")
-                            let songPart = L10n.string("\(trackCount) songs")
-                            Text(localized: "\(albumPart), \(songPart)")
-                                .font(Typography.caption)
-                                .foregroundStyle(Color.textSecondary)
+                        if let id = artist.id {
+                            let albumCount = self.vm.albumCounts[id] ?? 0
+                            let trackCount = self.vm.trackCounts[id] ?? 0
+                            if albumCount > 0 || trackCount > 0 {
+                                let albumPart = L10n.string("\(albumCount) albums")
+                                let songPart = L10n.string("\(trackCount) songs")
+                                Text(localized: "\(albumPart), \(songPart)")
+                                    .font(Typography.caption)
+                                    .foregroundStyle(Color.textSecondary)
+                            }
                         }
                     }
+
+                    Spacer()
+
+                    Image(systemName: "chevron.right")
+                        .font(Typography.caption)
+                        .foregroundStyle(Color.textTertiary)
+                        .accessibilityHidden(true)
                 }
-
-                Spacer()
-
-                Image(systemName: "chevron.right")
-                    .font(Typography.caption)
-                    .foregroundStyle(Color.textTertiary)
-                    .accessibilityHidden(true)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
             }
-            .contentShape(Rectangle())
-            .tag(artist.id)
-            .accessibilityElement(children: .combine)
+            .buttonStyle(.plain)
             .accessibilityLabel(artist.name)
+            .accessibilityHint(L10n.string("Open artist"))
             .contextMenu {
                 if let id = artist.id {
                     Button(L10n.string("Remove Artist from Library"), role: .destructive) {
@@ -405,15 +410,13 @@ public struct ArtistsView: View {
                 }
             }
         }
-        // Reset to nil so the same artist can be re-selected on the next tap.
-        .onChange(of: self.vm.selectedArtistID) { _, id in
-            if let id {
-                self.vm.selectedArtistID = nil
-                // Snapshot the visited artist so the list scrolls it back into
-                // view when it's rebuilt on the way back (#349-style restore).
-                self.vm.lastVisitedArtistID = id
-                Task { await self.library.selectDestination(.artist(id)) }
-            }
-        }
+    }
+
+    private func openArtist(_ artist: Artist) {
+        guard let id = artist.id else { return }
+        // Snapshot the visited artist so the list scrolls it back into view
+        // when it's rebuilt on the way back (#349-style restore).
+        self.vm.lastVisitedArtistID = id
+        Task { await self.library.selectDestination(.artist(id)) }
     }
 }

--- a/Modules/UI/Tests/UITests/ViewModelTests/ArtistsScrollRestoreConventionTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/ArtistsScrollRestoreConventionTests.swift
@@ -19,12 +19,20 @@ struct ArtistsScrollRestoreConventionTests {
         return try String(contentsOf: url, encoding: .utf8)
     }
 
-    @Test("Artist rows provide selection tags so clicks can navigate")
-    func artistRowsProvideSelectionTags() throws {
+    @Test("Artist rows navigate directly when clicked")
+    func artistRowsNavigateDirectlyWhenClicked() throws {
         let source = try self.artistsSource()
         #expect(
-            source.contains(".tag(artist.id)"),
-            "List(selection:) only updates selectedArtistID when each artist row has a matching tag"
+            source.contains("Button {") && source.contains("self.openArtist(artist)"),
+            "artist rows must be buttons that navigate directly instead of relying on List selection"
+        )
+        #expect(
+            source.contains("Task { await self.library.selectDestination(.artist(id)) }"),
+            "the artist click handler must navigate to the selected artist"
+        )
+        #expect(
+            !source.contains("selection: self.$vm.selectedArtistID"),
+            "artist navigation must not depend on unreliable List selection changes"
         )
     }
 


### PR DESCRIPTION
## Summary

- replace selection-driven artist navigation with a direct row button action
- preserve last-visited artist scroll restoration and the existing context menu
- replace the false-positive selection-tag convention test with checks for direct navigation

## Context

This is a follow-up to #360. That PR shipped in Bòcan 2.2.0, but adding
`.tag(artist.id)` did not restore navigation in the released app. Clicking a
local artist row still focused the list without opening the artist.

## Root cause

The previous fix addressed row identity, but navigation still depended on
`List(selection:)` updating `selectedArtistID` and a subsequent `onChange`
handler. The explicit tag did not make that selection event reliable, and the
source-convention test only proved that the tag was present rather than that a
click initiated navigation.

This change removes that indirect state transition. Each artist row is now a
plain-styled `Button` that snapshots `lastVisitedArtistID` and calls
`selectDestination(.artist(id))` directly.

## User impact

Clicking an artist in Local Library > Artists reliably opens that artist's
albums and songs. Sorting, context menus, and scroll restoration are unchanged.

Because the incomplete fix is already part of 2.2.0, this would be a good
candidate for a 2.2.1 patch release.

## Validation

- reproduced the failure in the installed Bòcan 2.2.0 release
- rebuilt the app from current `main` and manually verified artist navigation with a real local library
- `swift test --filter Artists` — 9 tests passed
- `make lint` — 0 violations
- `make format-check` — 0 files require formatting
- `make build XCB_OVERRIDE=CODE_SIGNING_ALLOWED=NO` — succeeded
