### PR TITLE
fix(playback): show album artwork without Now Playing crashes

### DIFF
--- a/Modules/Playback/Sources/Playback/NowPlaying/NowPlayingCentre.swift
+++ b/Modules/Playback/Sources/Playback/NowPlaying/NowPlayingCentre.swift
@@ -4,6 +4,13 @@ import MediaPlayer
 import Observability
 import Persistence
 
+// MARK: - ArtworkPayload
+
+private struct ArtworkPayload: Sendable {
+    let data: Data
+    let boundsSize: CGSize
+}
+
 // MARK: - NowPlayingCentre
 
 /// Updates `MPNowPlayingInfoCenter` and manages the 1 Hz position ticker.
@@ -18,6 +25,12 @@ public final class NowPlayingCentre {
     private var isPlaying = false
     private var getPosition: (@Sendable () async -> TimeInterval)?
 
+    /// Monotonic token guarding against a late-arriving artwork load from a
+    /// superseded track overwriting the now-playing info of the current one.
+    /// Bumped on every `update(track:…)` / `clear()`; in-flight loads compare
+    /// their captured token against this and bail if they've been superseded.
+    private var artworkToken: UInt64 = 0
+
     private let log = AppLogger.make(.playback)
 
     // MARK: - Init
@@ -26,10 +39,13 @@ public final class NowPlayingCentre {
 
     // MARK: - Public API
 
-    /// Update the displayed track. Artwork is loaded from `coverArtPath` if available.
+    /// Update the displayed track. Artwork is loaded asynchronously from
+    /// `coverArtPath` (when non-`nil`) and applied to `nowPlayingInfo` once
+    /// ready; until then the system shows a generic audio glyph.
     public func update(
         track: Track,
         duration: TimeInterval,
+        coverArtPath: String? = nil,
         positionProvider: @Sendable @escaping () async -> TimeInterval
     ) {
         self.getPosition = positionProvider
@@ -42,8 +58,12 @@ public final class NowPlayingCentre {
         info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-        if self.isPlaying { self.startPositionTimer() }
+        if self.isPlaying {
+            self.startPositionTimer()
+        }
         self.log.debug("nowplaying.update", ["title": track.title ?? "unknown"])
+
+        self.loadArtwork(path: coverArtPath)
     }
 
     /// Update the displayed item for a podcast episode. Maps the episode title
@@ -73,7 +93,9 @@ public final class NowPlayingCentre {
         info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
 
         MPNowPlayingInfoCenter.default().nowPlayingInfo = info
-        if self.isPlaying { self.startPositionTimer() }
+        if self.isPlaying {
+            self.startPositionTimer()
+        }
         self.log.debug("nowplaying.update.podcast", ["title": title, "show": showName])
     }
 
@@ -94,12 +116,71 @@ public final class NowPlayingCentre {
     /// Clear the now-playing info (e.g. when queue is exhausted).
     public func clear() {
         self.stopPositionTimer()
+        self.artworkToken &+= 1
         MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
         self.getPosition = nil
         self.log.debug("nowplaying.clear")
     }
 
     // MARK: - Private
+
+    /// Loads artwork from `path` off the main thread and applies it to
+    /// `nowPlayingInfo` on completion. A monotonic token guards against a
+    /// late-arriving image from a superseded track overwriting the current
+    /// track's now-playing info (e.g. when skipping quickly between tracks).
+    private func loadArtwork(path: String?) {
+        self.artworkToken &+= 1
+        let token = self.artworkToken
+        guard let path else { return }
+
+        Task { [weak self] in
+            // Keep file I/O and image inspection off the main thread. Only
+            // Sendable value types cross back to the main actor.
+            let payload = await Task.detached(priority: .utility) { () -> ArtworkPayload? in
+                guard let data = FileManager.default.contents(atPath: path),
+                      !data.isEmpty,
+                      let image = NSImage(data: data) else {
+                    return nil
+                }
+                return ArtworkPayload(data: data, boundsSize: image.size)
+            }.value
+
+            guard let self else { return }
+            // Bail if a newer `update` / `clear` superseded this load.
+            guard self.artworkToken == token else { return }
+            guard let payload else {
+                self.log.debug("nowplaying.artwork.load_failed", ["path": path])
+                return
+            }
+            // No suspension point between the token check and the write, so a
+            // concurrent `update` cannot slip in and clobber our mutation.
+            var current = MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [:]
+            current[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
+                boundsSize: payload.boundsSize,
+                requestHandler: Self.artworkRequestHandler(data: payload.data)
+            )
+            MPNowPlayingInfoCenter.default().nowPlayingInfo = current
+            self.log.debug("nowplaying.artwork.set", ["path": path])
+        }
+    }
+
+    /// MediaPlayer invokes this callback on its private access queue. Building
+    /// it inline in a `@MainActor` method makes Swift 6 enforce main-actor
+    /// isolation at runtime, so construct an explicitly Sendable callback that
+    /// captures only image data and decodes on the requesting queue.
+    nonisolated static func artworkRequestHandler(
+        data: Data
+    ) -> @Sendable (CGSize) -> NSImage {
+        { requestedSize in
+            guard let image = NSImage(data: data) else {
+                let fallbackSize = requestedSize.width > 0 && requestedSize.height > 0
+                    ? requestedSize
+                    : CGSize(width: 1, height: 1)
+                return NSImage(size: fallbackSize)
+            }
+            return image
+        }
+    }
 
     private func startPositionTimer() {
         self.stopPositionTimer()

--- a/Modules/Playback/Sources/Playback/QueuePlayer.swift
+++ b/Modules/Playback/Sources/Playback/QueuePlayer.swift
@@ -88,6 +88,7 @@ public actor QueuePlayer: Transport {
     private var albumRepo: AlbumRepository
     private var artistRepo: ArtistRepository
     private var rootRepo: LibraryRootRepository
+    private var coverArtRepo: CoverArtRepository
     private var lastEmittedState: PlaybackState = .idle
 
     /// Timestamp of the most recent gapless transition, used to suppress a
@@ -144,6 +145,7 @@ public actor QueuePlayer: Transport {
         self.albumRepo = AlbumRepository(database: database)
         self.artistRepo = ArtistRepository(database: database)
         self.rootRepo = LibraryRootRepository(database: database)
+        self.coverArtRepo = CoverArtRepository(database: database)
 
         var continuation: AsyncStream<PlaybackState>.Continuation?
         self.state = AsyncStream { continuation = $0 }
@@ -718,9 +720,11 @@ public actor QueuePlayer: Transport {
             )
         } else if let track {
             let capturedEngine = self.engine
+            let coverPath = await self.resolveCoverArtPath(for: track)
             await self.nowPlayingCentre?.update(
                 track: track,
                 duration: item.duration,
+                coverArtPath: coverPath,
                 positionProvider: { await capturedEngine.currentTime }
             )
         }
@@ -745,6 +749,36 @@ public actor QueuePlayer: Transport {
         }
     }
 
+    /// Resolves the on-disk cover-art path for a track, preferring the
+    /// track's own embedded art (unique per-track art, e.g. a single with
+    /// distinct artwork) and falling back to the album's cached path.
+    /// Returns `nil` when no art is available; `NowPlayingCentre` then
+    /// shows the system's generic audio glyph.
+    private func resolveCoverArtPath(for track: Track) async -> String? {
+        if let hash = track.coverArtHash {
+            do {
+                if let art = try await self.coverArtRepo.fetch(hash: hash) {
+                    return art.path
+                }
+            } catch {
+                self.log.warning("queueplayer.cover_art.fetch_failed", [
+                    "error": String(reflecting: error),
+                ])
+            }
+        }
+        if let albumID = track.albumID {
+            do {
+                return try await self.albumRepo.fetch(id: albumID).coverArtPath
+            } catch {
+                self.log.warning("queueplayer.album.fetch_failed", [
+                    "albumID": albumID,
+                    "error": String(reflecting: error),
+                ])
+            }
+        }
+        return nil
+    }
+
     /// Dispatches start-of-track notifications to the history recorder using
     /// the Subsonic-specific overload when the item streams from a remote
     /// server. Subsonic items don't have a row in the local `tracks` table,
@@ -752,10 +786,14 @@ public actor QueuePlayer: Transport {
     private func notifyHistoryStart(for item: QueueItem) async {
         // Internet radio is a live stream — no track row, no scrobble.
         // Skip the history recorder entirely.
-        if case .internetRadio = item.playableSource { return }
+        if case .internetRadio = item.playableSource {
+            return
+        }
         // Podcasts are not music tracks and never scrobble to Last.fm /
         // ListenBrainz. Skip the recorder so no scrobble is ever enqueued.
-        if case .podcast = item.playableSource { return }
+        if case .podcast = item.playableSource {
+            return
+        }
         if case let .subsonic(serverID, songID) = item.playableSource {
             let context = SubsonicPlayContext(
                 serverID: serverID,
@@ -951,8 +989,12 @@ public actor QueuePlayer: Transport {
     }
 
     private static func isMissingFileError(_ error: Error) -> Bool {
-        if case AudioEngineError.fileNotFound = error { return true }
-        if case PlaybackError.bookmarkResolutionFailed = error { return true }
+        if case AudioEngineError.fileNotFound = error {
+            return true
+        }
+        if case PlaybackError.bookmarkResolutionFailed = error {
+            return true
+        }
         return false
     }
 
@@ -1030,8 +1072,12 @@ public actor QueuePlayer: Transport {
 
         // CUE virtual tracks require segment-offset handling that the gapless
         // path doesn't support. Fall back to normal stop/load/play transition.
-        if item.isCUETrack { return nil }
-        if await self.queue.currentItem?.isCUETrack == true { return nil }
+        if item.isCUETrack {
+            return nil
+        }
+        if await self.queue.currentItem?.isCUETrack == true {
+            return nil
+        }
 
         // Determine whether the next item's album has `force_gapless` set and
         // the current item belongs to the same album.
@@ -1103,7 +1149,9 @@ public actor QueuePlayer: Transport {
 
         // Fail early if the file is unreachable — avoids opaque AVAudioFile errors.
         guard FileManager.default.fileExists(atPath: url.path) else {
-            if resolvedFromPerFileBookmark { url.stopAccessingSecurityScopedResource() }
+            if resolvedFromPerFileBookmark {
+                url.stopAccessingSecurityScopedResource()
+            }
             // `rootScope` deinit releases on return.
             throw PlaybackError.bookmarkResolutionFailed(
                 trackID: item.trackID,
@@ -1121,7 +1169,9 @@ public actor QueuePlayer: Transport {
                 }
             }
         } catch {
-            if resolvedFromPerFileBookmark { url.stopAccessingSecurityScopedResource() }
+            if resolvedFromPerFileBookmark {
+                url.stopAccessingSecurityScopedResource()
+            }
             // `rootScope` deinit releases on return.
             throw error
         }
@@ -1207,9 +1257,11 @@ public actor QueuePlayer: Transport {
         } else if let track = try? await trackRepo.fetch(id: item.trackID) {
             self.emitCurrentTrack(track)
             let capturedEngine = self.engine
+            let coverPath = await self.resolveCoverArtPath(for: track)
             await self.nowPlayingCentre?.update(
                 track: track,
                 duration: item.duration,
+                coverArtPath: coverPath,
                 positionProvider: { await capturedEngine.currentTime }
             )
         }
@@ -1451,7 +1503,9 @@ public actor QueuePlayer: Transport {
         var artistNames: [Int64: String] = [:]
         artistNames.reserveCapacity(artists.count)
         for a in artists {
-            if let aid = a.id { artistNames[aid] = a.name }
+            if let aid = a.id {
+                artistNames[aid] = a.name
+            }
         }
         var items: [QueueItem] = []
         items.reserveCapacity(trackIDs.count)

--- a/Modules/Playback/Tests/PlaybackTests/NowPlayingTests.swift
+++ b/Modules/Playback/Tests/PlaybackTests/NowPlayingTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import Persistence
 import Testing
@@ -82,6 +83,58 @@ struct NowPlayingTests {
         centre.setPlaying(true)
         centre.setPlaying(false)
         // Verify no crash; actual MPNowPlayingInfoCenter state is app-level.
+    }
+
+    @Test("update with missing coverArtPath does not crash")
+    @MainActor
+    func updateWithMissingArtworkPath() async throws {
+        let centre = NowPlayingCentre()
+        let track = self.makeTrack(title: "Artwork Test")
+        centre.update(
+            track: track,
+            duration: 200,
+            coverArtPath: "/nonexistent/cover.jpg",
+            positionProvider: { 0 }
+        )
+        // Give the off-main load a moment to settle before clearing.
+        try await Task.sleep(nanoseconds: 200_000_000)
+        centre.clear()
+    }
+
+    @Test("rapid update supersedes in-flight artwork load without crash")
+    @MainActor
+    func rapidUpdateSupersedesArtwork() async throws {
+        let centre = NowPlayingCentre()
+        // First update kicks off an artwork load against a bogus path.
+        centre.update(
+            track: self.makeTrack(title: "A"),
+            duration: 100,
+            coverArtPath: "/nonexistent/a.jpg",
+            positionProvider: { 0 }
+        )
+        // Second update supersedes it immediately with a different track and no art.
+        centre.update(
+            track: self.makeTrack(title: "B"),
+            duration: 100,
+            coverArtPath: nil,
+            positionProvider: { 0 }
+        )
+        try await Task.sleep(nanoseconds: 200_000_000)
+        centre.clear()
+    }
+
+    @Test("artwork request handler can run off the main actor")
+    func artworkRequestHandlerRunsOffMainActor() async throws {
+        let encodedPNG = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+        let data = try #require(Data(base64Encoded: encodedPNG))
+        let requestHandler = NowPlayingCentre.artworkRequestHandler(data: data)
+
+        let imageSize = await Task.detached {
+            requestHandler(CGSize(width: 64, height: 64)).size
+        }.value
+
+        #expect(imageSize.width > 0)
+        #expect(imageSize.height > 0)
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
# PR description

## Summary

- Show cached track or album artwork in macOS Now Playing and Control Center.
- Prevent the MediaPlayer artwork callback from inheriting `@MainActor` isolation.
- Guard asynchronous artwork loads so a late result cannot overwrite the current track.

## Root cause

`NowPlayingCentre` previously built the `MPMediaItemArtwork` request handler inside its `@MainActor` context. MediaPlayer invokes that handler on its private access queue while converting artwork to JPEG. Swift 6 detected the executor mismatch and stopped in `_dispatch_assert_queue_fail`.

## Changes

- Resolve cover art from the track's `coverArtHash`, with album cover art as the fallback.
- Load artwork bytes and inspect image dimensions away from the main actor.
- Build an explicitly `nonisolated`, `@Sendable` artwork request handler that captures only `Data`.
- Keep `MPNowPlayingInfoCenter` mutations on the main actor.
- Add a monotonic token so rapid track changes invalidate stale artwork loads.
- Add regression coverage that invokes the artwork request handler from a detached executor.

## Verification

- [x] `make build`
- [x] `make lint`
- [x] `make test-playback`
- [x] Off-main artwork request handler regression test
- [ ] `make test-coverage` could not complete locally because the checked-in signing team has no matching Mac Development certificate on this machine. CI should run this gate with its configured signing environment.

## Scope

- Implements the music artwork requirement in [`docs/design-spec/phase-05-queue-gapless.md`](docs/design-spec/phase-05-queue-gapless.md).
- Podcast episode artwork remains unchanged and is outside this PR.

## Review notes

- The crash was captured in `Bocan-2026-07-25-172220.ips` on MediaPlayer's private `accessQueue`.

## Screenshoot

## Before

<img width="1512" height="982" alt="Screenshot 2026-07-25 at 18 16 46" src="https://github.com/user-attachments/assets/e455f3c3-ee98-49ee-b8f6-632370038119" />

## After
<img width="391" height="195" alt="Screenshot 2026-07-25 at 18 05 21" src="https://github.com/user-attachments/assets/198bce0f-7642-45ad-9d91-2819c1fb290d" />

<img width="1512" height="982" alt="Screenshot 2026-07-25 at 18 05 57" src="https://github.com/user-attachments/assets/a7ce39d3-47f6-4f9a-81f5-5a2caff609a6" />
