### PR TITLE
fix(ci): stop xcbeautify masking build failures, and build ad-hoc signed on runners

### DIFF
--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -67,7 +67,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Cache SPM packages
         uses: actions/cache@v6

--- a/.github/workflows/branch.yml
+++ b/.github/workflows/branch.yml
@@ -24,6 +24,10 @@ defaults:
   run:
     shell: bash
 
+env:
+  # The runner has no signing certificate: build ad-hoc, no team, no entitlements.
+  XCB_OVERRIDE: "CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS="
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Cache SPM packages
         uses: actions/cache@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Explicit bash gives `-o pipefail`; the implicit default is `bash -e` only,
+# which let `make test-coverage | xcbeautify` report green on a failed build
+# from 2026-06-02 until 2026-08-30 (see ADR-033).
+defaults:
+  run:
+    shell: bash
+
+env:
+  # The runner has no signing certificate: build ad-hoc, no team, no entitlements.
+  XCB_OVERRIDE: "CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS="
+
 jobs:
   build-and-test:
     name: Build & Test

--- a/.github/workflows/dependency-drift.yml
+++ b/.github/workflows/dependency-drift.yml
@@ -17,6 +17,10 @@ permissions:
   contents: read
   issues: write
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
           echo "Release PR for ${VERSION} is merged: manifest and CHANGELOG agree."
 
       - name: Select Xcode 26
-        run: sudo xcode-select -s /Applications/Xcode_26.5.app
+        run: sudo xcode-select -s /Applications/Xcode_26.6.app
 
       - name: Cache Homebrew packages
         uses: actions/cache@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,12 @@ on:
 permissions:
   contents: write
 
+# Explicit bash gives `-o pipefail`, so a failed `make ... | xcbeautify` fails
+# the step (see ADR-033).
+defaults:
+  run:
+    shell: bash
+
 jobs:
   check-signing:
     name: Check signing secrets
@@ -148,6 +154,10 @@ jobs:
         run: make generate
 
       - name: Run tests before release (fail fast)
+        env:
+          # The Debug test build cannot use the Developer ID identity imported
+          # below: build it ad-hoc, no team, no entitlements.
+          XCB_OVERRIDE: "CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS="
         run: make test-coverage 2>&1 | xcbeautify
 
       - name: Import Developer ID certificate

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -22,6 +22,10 @@ concurrency:
   group: pages
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 jobs:
   build:
     name: Build site

--- a/Makefile
+++ b/Makefile
@@ -15,9 +15,11 @@ EXPECTED_SWIFTLINT := $(shell cat .swiftlint-version 2>/dev/null)
 EXPECTED_SWIFTFORMAT := $(shell cat .swiftformat-version 2>/dev/null)
 
 # Extra xcodebuild settings injected into `build`/`test`/`test-coverage`. Empty by
-# default. CI uses it to strip the keychain-access-groups entitlement on unsigned
-# ad-hoc builds (which otherwise demand a provisioning profile):
-#   make test-coverage XCB_OVERRIDE='CODE_SIGN_ENTITLEMENTS='
+# default, so a local build signs with the team in project.yml. CI runners have
+# no certificate, so every workflow exports this as an environment variable to
+# build ad-hoc signed with no team, and without the keychain-access-groups
+# entitlement (which ad-hoc signing cannot carry without a provisioning profile):
+#   XCB_OVERRIDE='CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS='
 XCB_OVERRIDE ?=
 
 ## tests: Run format, lint, full test matrix — one line per stage, errors shown inline
@@ -98,7 +100,7 @@ generate:
 
 ## build: Build the Debug configuration
 build:
-	xcodebuild \
+	set -o pipefail && xcodebuild \
 		-project Bocan.xcodeproj \
 		-scheme Bocan \
 		-configuration Debug \
@@ -283,7 +285,7 @@ test-observability:
 
 ## uitest: Run UI smoke tests (BocanUITests scheme target)
 uitest:
-	xcodebuild \
+	set -o pipefail && xcodebuild \
 		-project Bocan.xcodeproj \
 		-scheme Bocan \
 		-configuration Debug \

--- a/UITests/Menus/MenuManifest.swift
+++ b/UITests/Menus/MenuManifest.swift
@@ -26,7 +26,13 @@ enum MenuState: String, CaseIterable {
 /// canonical. Shortcuts are declared as display strings ("⇧⌘N") and
 /// parsed into `MenuShortcut` for comparison, so the manifest reads like
 /// the help book's table.
-struct MenuItemSpec {
+///
+/// `Sendable` is explicit, not redundant: `submenu` makes the type
+/// self-referential, and implicit Sendable inference through that cycle is
+/// order-dependent. On CI runners (different batch partitioning) it resolved
+/// to non-Sendable and `MenuManifest.menus` failed to compile (2026-08-30).
+// swiftformat:disable:next redundantSendable
+struct MenuItemSpec: Sendable {
     let titles: [String]
     /// Expected shortcut; the parity test checks it against the source
     /// declaration and `KeyBindings.swift`.
@@ -88,8 +94,10 @@ struct MenuItemSpec {
 
 // MARK: - MenuSpec
 
-/// One expected top-level menu.
-struct MenuSpec {
+/// One expected top-level menu. `Sendable` is explicit for the same reason
+/// as `MenuItemSpec`: it is what `MenuManifest.menus` stores.
+// swiftformat:disable:next redundantSendable
+struct MenuSpec: Sendable {
     let title: String
     /// `false` for menus whose contents are wholly system-managed and
     /// machine-dependent (Window: tiling, tab items, open-window list).


### PR DESCRIPTION
## The bug

Since 2 June, `make test-coverage` has failed on every CI runner (`No signing certificate "Mac Development" found`, exit 65, `Executed 0 tests`) and reported green, because `make test-coverage 2>&1 | xcbeautify` ran under GitHub's default `bash -e` with no `pipefail`. Only the SPM package suites were really running. The release workflow's "run tests before release" step has the same mask, and the Makefile `build` recipe pipes into xcbeautify without `pipefail` at all, so `make build` could never fail anywhere, including in `branch.yml`.

Cause: `4de9bec6` gave the Debug config `DEVELOPMENT_TEAM` + automatic signing (needed so Keychain items survive rebuilds locally) and `8166fd01` removed CI's `XCB_OVERRIDE` the same day. The runner has no certificate.

## The fix

- `Makefile`: `set -o pipefail` in the `build` and UI-test recipes; `XCB_OVERRIDE` documented as the CI signing knob.
- Every workflow gets `defaults.run.shell: bash`, which brings `pipefail`.
- `ci.yml`, `branch.yml` and `release.yml`'s test step export `XCB_OVERRIDE="CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS="`: ad-hoc, no team, no entitlements, which is what CI did before June. Local builds are unaffected.

Verified locally: the override builds in 18 s; `make build` with a bad flag now exits 2. This PR's own `Build & Test` run is the first honest run of the Xcode suite on CI since June, so expect it to take longer than the usual 7 minutes, and it may surface test failures that have been hidden.

`codeql.yml` is left alone because #428 deletes it. #428 will merge `main` after this lands.

Details: ADR-033, note dated 2026-08-30.