### PR TITLE
test(e2e): give setUp and tearDown overrides the test classes' MainActor isolation

### DIFF
--- a/UITests/Audits/IdentifierAuditTests.swift
+++ b/UITests/Audits/IdentifierAuditTests.swift
@@ -22,7 +22,7 @@ import XCTest
 final class IdentifierAuditTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Journeys/CueMarkerJourneyTests.swift
+++ b/UITests/Journeys/CueMarkerJourneyTests.swift
@@ -11,12 +11,12 @@ import XCTest
 final class CueMarkerJourneyTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         self.session = nil
     }
 

--- a/UITests/Journeys/FoundationJourneys.swift
+++ b/UITests/Journeys/FoundationJourneys.swift
@@ -9,12 +9,12 @@ import XCTest
 final class FoundationJourneys: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         // No filesystem teardown: the runner cannot delete inside the app's
         // container. The app sweeps stale run homes on its next E2E launch.
         self.session = nil

--- a/UITests/Menus/MenuCrawlTests.swift
+++ b/UITests/Menus/MenuCrawlTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class MenuCrawlTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Menus/MenuEnablementTests.swift
+++ b/UITests/Menus/MenuEnablementTests.swift
@@ -15,7 +15,7 @@ import XCTest
 final class MenuEnablementTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Menus/MenuInvocationTests.swift
+++ b/UITests/Menus/MenuInvocationTests.swift
@@ -19,7 +19,7 @@ final class MenuInvocationTests: XCTestCase {
     private var firstTone = ""
     private var otherTone = ""
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Podcasts/PodcastJourneyTests.swift
+++ b/UITests/Podcasts/PodcastJourneyTests.swift
@@ -10,7 +10,7 @@ final class PodcastJourneyTests: XCTestCase {
     private var session: E2ESession!
     private var server: E2EPodcastServer!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
         // Long enough that a single 30s skip-forward (the resume journey)
@@ -18,9 +18,8 @@ final class PodcastJourneyTests: XCTestCase {
         self.server = try E2EPodcastServer(showTitle: "E2E Test Cast", episodeSeconds: 60)
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         self.server?.stop()
-        super.tearDown()
     }
 
     // MARK: - Subscribe + episode list

--- a/UITests/Radio/RadioStreamJourneyTests.swift
+++ b/UITests/Radio/RadioStreamJourneyTests.swift
@@ -11,7 +11,7 @@ final class RadioStreamJourneyTests: XCTestCase {
     private var session: E2ESession!
     private var server: E2EStreamServer!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
         self.server = try E2EStreamServer(
@@ -21,9 +21,8 @@ final class RadioStreamJourneyTests: XCTestCase {
         )
     }
 
-    override func tearDown() {
+    override func tearDown() async throws {
         self.server?.stop()
-        super.tearDown()
     }
 
     // MARK: - Add by URL

--- a/UITests/Surfaces/BrowseSurfaceTests.swift
+++ b/UITests/Surfaces/BrowseSurfaceTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class BrowseSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Surfaces/PlaylistSurfaceTests.swift
+++ b/UITests/Surfaces/PlaylistSurfaceTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class PlaylistSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Surfaces/RadioSurfaceTests.swift
+++ b/UITests/Surfaces/RadioSurfaceTests.swift
@@ -9,7 +9,7 @@ import XCTest
 final class RadioSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Surfaces/SearchSurfaceTests.swift
+++ b/UITests/Surfaces/SearchSurfaceTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class SearchSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Surfaces/ToolbarSurfaceTests.swift
+++ b/UITests/Surfaces/ToolbarSurfaceTests.swift
@@ -15,7 +15,7 @@ import XCTest
 final class ToolbarSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Surfaces/TransportSurfaceTests.swift
+++ b/UITests/Surfaces/TransportSurfaceTests.swift
@@ -13,7 +13,7 @@ import XCTest
 final class TransportSurfaceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Visualizers/VisualizerLivenessTests.swift
+++ b/UITests/Visualizers/VisualizerLivenessTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class VisualizerLivenessTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Windows/FullScreenTests.swift
+++ b/UITests/Windows/FullScreenTests.swift
@@ -22,12 +22,12 @@ final class FullScreenTests: XCTestCase {
     private var session: E2ESession!
     private var app: XCUIApplication?
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() async throws {
         // Guarantee the app is windowed before it is torn down, whatever the
         // test outcome, so a wedged full-screen Space can never survive.
         guard let app = self.app else { return }

--- a/UITests/Windows/MiniPlayerWindowTests.swift
+++ b/UITests/Windows/MiniPlayerWindowTests.swift
@@ -14,7 +14,7 @@ import XCTest
 final class MiniPlayerWindowTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Windows/SecondaryWindowsTests.swift
+++ b/UITests/Windows/SecondaryWindowsTests.swift
@@ -10,7 +10,7 @@ import XCTest
 final class SecondaryWindowsTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Windows/SettingsCrawlTests.swift
+++ b/UITests/Windows/SettingsCrawlTests.swift
@@ -11,7 +11,7 @@ import XCTest
 final class SettingsCrawlTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }

--- a/UITests/Windows/SettingsPersistenceTests.swift
+++ b/UITests/Windows/SettingsPersistenceTests.swift
@@ -12,7 +12,7 @@ import XCTest
 final class SettingsPersistenceTests: XCTestCase {
     private var session: E2ESession!
 
-    override func setUpWithError() throws {
+    override func setUp() async throws {
         continueAfterFailure = false
         self.session = E2ESession.make(named: self.name.sanitizedTestName)
     }


### PR DESCRIPTION
Follow-up from the ADR-033 slice-3 work, which surfaced 25 isolation diagnostics in the E2E target that a stale local module cache had been hiding (warnings on Xcode 26.6, errors on 26.5).

The `@MainActor` test classes overrode the nonisolated synchronous `setUpWithError`/`tearDown`, making every `session`/`server`/`app` access in them an isolation violation. The async variants are allowed to take the class's isolation, so 20 files move to `setUp() async throws` / `tearDown() async throws`. The two sync `tearDown`s drop `super.tearDown()`: XCTest calls each teardown variant itself, so the call would have run the base sync teardown twice.

Mechanical change, reviewed line by line: 20 setUp conversions, 5 tearDown conversions, 2 dropped `super.tearDown()` lines, nothing else.

Verified: clean rebuild of `BocanUITests` with zero isolation warnings (was 25); `make lint` and `make format-check` green; `make test-e2e-smoke` at runtime: 6 tests, 0 failures. Test-only, hence `skip-changelog`.