### PR TITLE
fix(library): Deep Dive searches MusicBrainz by name for albums and tracks without ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Deep Dive can now find an album or song on MusicBrainz by name when your files carry no MusicBrainz tags, instead of giving up. A match found this way is labelled in the report, and searches ignore stray spaces around names.
+
 ## [2.11.0](https://github.com/bocan/bocan-music/compare/v2.10.0...v2.11.0) (2026-08-29)
 
 Deep Dive (off by default)

--- a/Modules/Acoustics/Sources/Acoustics/MBRecording.swift
+++ b/Modules/Acoustics/Sources/Acoustics/MBRecording.swift
@@ -140,9 +140,11 @@ public struct MBReleaseGroup: Decodable, Sendable {
     public let firstReleaseDate: String?
     public let artistCredit: [MBArtistCredit]?
     public let releases: [MBRelease]?
+    /// Lucene relevance, 0–100. Search results only; nil on lookups and browses.
+    public let score: Int?
 
     enum CodingKeys: String, CodingKey {
-        case id, title, releases
+        case id, title, releases, score
         case primaryType = "primary-type"
         case secondaryTypes = "secondary-types"
         case firstReleaseDate = "first-release-date"
@@ -157,6 +159,30 @@ public struct MBReleaseGroup: Decodable, Sendable {
         guard let d = self.firstReleaseDate, d.count >= 4 else { return nil }
         return Int(d.prefix(4))
     }
+}
+
+/// One result of `GET /ws/2/recording?query=…`: the search shape is a light
+/// recording plus the Lucene relevance score, distinct from the full
+/// `MBRecording` lookup shape.
+public struct MBRecordingSearchResult: Decodable, Sendable {
+    public let id: String
+    public let title: String?
+    /// Lucene relevance, 0–100.
+    public let score: Int?
+    public let artistCredit: [MBArtistCredit]?
+
+    enum CodingKeys: String, CodingKey {
+        case id, title, score
+        case artistCredit = "artist-credit"
+    }
+
+    public var artistName: String {
+        self.artistCredit?.map { ($0.name ?? $0.artist?.name ?? "") + ($0.joinphrase ?? "") }.joined() ?? ""
+    }
+}
+
+public struct MBRecordingSearchResponse: Decodable, Sendable {
+    public let recordings: [MBRecordingSearchResult]
 }
 
 public struct MBTrack: Decodable, Sendable {

--- a/Modules/Acoustics/Sources/Acoustics/MusicBrainzClient.swift
+++ b/Modules/Acoustics/Sources/Acoustics/MusicBrainzClient.swift
@@ -111,6 +111,19 @@ public actor MusicBrainzClient {
         ).releaseGroups
     }
 
+    /// Searches recordings by artist + title, best score first, for guessing
+    /// a recording MBID the tags did not supply (Deep Dive).
+    public func searchRecordings(artist: String, title: String, limit: Int = 10) async throws -> [MBRecordingSearchResult] {
+        let query = "artist:\"\(artist.mbEscaped)\" AND recording:\"\(title.mbEscaped)\""
+        return try await self.get(
+            "recording",
+            query: ["query": query, "limit": String(limit)],
+            as: MBRecordingSearchResponse.self,
+            op: "mb.recording.search",
+            context: title
+        ).recordings
+    }
+
     /// Browses an artist's release groups (their discography); page with `offset`.
     public func browseReleaseGroups(artistMBID: String, limit: Int = 100, offset: Int = 0) async throws -> MBReleaseGroupBrowse {
         try await self.get(

--- a/Modules/Acoustics/Tests/AcousticsTests/Fixtures/mb_recording_search.json
+++ b/Modules/Acoustics/Tests/AcousticsTests/Fixtures/mb_recording_search.json
@@ -1,0 +1,33 @@
+{
+ "created": "2026-08-30T00:00:00.000Z",
+ "count": 2,
+ "offset": 0,
+ "recordings": [
+  {
+   "id": "4c305d49-1dae-4790-b508-3fa8d43c01a1",
+   "score": 100,
+   "title": "The Messenger",
+   "length": 331000,
+   "artist-credit": [
+    {
+     "name": "Lisa Gerrard",
+     "artist": {
+      "id": "a-lg",
+      "name": "Lisa Gerrard",
+      "sort-name": "Gerrard, Lisa"
+     }
+    }
+   ]
+  },
+  {
+   "id": "r-other",
+   "score": 45,
+   "title": "Messenger",
+   "artist-credit": [
+    {
+     "name": "Someone Else"
+    }
+   ]
+  }
+ ]
+}

--- a/Modules/Acoustics/Tests/AcousticsTests/MusicBrainzEntityTests.swift
+++ b/Modules/Acoustics/Tests/AcousticsTests/MusicBrainzEntityTests.swift
@@ -22,12 +22,30 @@ struct MusicBrainzEntityTests {
         #expect(groups.first?.artistName == "The Beatles")
         #expect(groups.first?.year == 1969)
         #expect(groups.first?.primaryType == "Album")
+        #expect(groups.first?.score == 100, "search results carry the Lucene score")
         #expect(groups.last?.secondaryTypes == ["Compilation"])
+        #expect(groups.last?.score == 61)
         let url = try #require(mock.lastRequest?.url?.absoluteString.removingPercentEncoding)
         #expect(url.contains("/ws/2/release-group?"))
         #expect(url.contains("query=artist:\"The Beatles\" AND releasegroup:\"Abbey Road\""))
         #expect(url.hasSuffix("fmt=json"))
         #expect(mock.lastRequest?.value(forHTTPHeaderField: "User-Agent") == "Bocan/test ( https://bocan.app )")
+    }
+
+    @Test("searchRecordings decodes the search shape with scores and builds the query")
+    func recordingSearch() async throws {
+        let mock = MockHTTPClient()
+        mock.responseData = Bundle.fixtureData(named: "Fixtures/mb_recording_search.json")
+        let results = try await self.makeClient(mock).searchRecordings(artist: "Lisa Gerrard", title: "The Messenger")
+        #expect(results.count == 2)
+        #expect(results.first?.id == "4c305d49-1dae-4790-b508-3fa8d43c01a1")
+        #expect(results.first?.score == 100)
+        #expect(results.first?.title == "The Messenger")
+        #expect(results.first?.artistName == "Lisa Gerrard")
+        #expect(results.last?.score == 45)
+        let url = try #require(mock.lastRequest?.url?.absoluteString.removingPercentEncoding)
+        #expect(url.contains("/ws/2/recording?"))
+        #expect(url.contains("query=artist:\"Lisa Gerrard\" AND recording:\"The Messenger\""))
     }
 
     @Test("fetchArtist decodes life span, members with dates, and links")

--- a/Modules/Library/Sources/Library/DeepDive/DeepDiveModels.swift
+++ b/Modules/Library/Sources/Library/DeepDive/DeepDiveModels.swift
@@ -84,6 +84,10 @@ public struct AlbumReport: Codable, Sendable, Equatable {
     /// True when the album carried only a release-group id and a
     /// representative release was chosen (earliest official).
     public let releaseChosen: Bool
+    /// True when the tags carried no MusicBrainz id at all and the release
+    /// group came from a confident name search. Never persisted: the album
+    /// MBID columns are rolled up from tracks by the scanner.
+    public let mbidGuessed: Bool
     public let primaryType: String?
     public let secondaryTypes: [String]
     public let date: String?
@@ -105,6 +109,9 @@ public struct AlbumReport: Codable, Sendable, Equatable {
 }
 
 /// A concise recording report for a track.
+/// - Note: `mbidGuessed` is true when the tags carried no recording id and
+///   the recording came from a confident artist + title search; the guess is
+///   shown, labelled, and never written back to the track row.
 public struct TrackReport: Codable, Sendable, Equatable {
     public struct Appearance: Codable, Sendable, Equatable {
         public let releaseTitle: String
@@ -126,6 +133,7 @@ public struct TrackReport: Codable, Sendable, Equatable {
 
     public let trackID: Int64
     public let recordingMBID: String
+    public let mbidGuessed: Bool
     public let title: String
     public let artistCredit: String
     /// Milliseconds.

--- a/Modules/Library/Sources/Library/DeepDive/DeepDiveService.swift
+++ b/Modules/Library/Sources/Library/DeepDive/DeepDiveService.swift
@@ -172,9 +172,20 @@ public actor DeepDiveService {
     }
 
     private func buildAlbumReport(_ album: Album) async throws -> AlbumReport {
+        var artist: Artist?
+        if let artistID = album.albumArtistID {
+            artist = try? await self.artists.fetch(id: artistID)
+        }
+
         var releaseChosen = false
+        var guessed = false
         var releaseID = album.musicbrainzReleaseID
-        if releaseID == nil, let groupID = album.musicbrainzReleaseGroupID {
+        var groupID = album.musicbrainzReleaseGroupID
+        if releaseID == nil, groupID == nil {
+            groupID = try await self.guessReleaseGroupMBID(album: album, artist: artist)
+            guessed = groupID != nil
+        }
+        if releaseID == nil, let groupID {
             let group = try await self.mapErrors { try await self.musicBrainz.fetchReleaseGroup(mbid: groupID) }
             releaseID = Self.representativeRelease(group.releases ?? [])?.id
             releaseChosen = releaseID != nil
@@ -182,10 +193,6 @@ public actor DeepDiveService {
         guard let releaseID else { throw DeepDiveError.noIdentifier }
         let release = try await self.mapErrors { try await self.musicBrainz.fetchRelease(mbid: releaseID) }
 
-        var artist: Artist?
-        if let artistID = album.albumArtistID {
-            artist = try? await self.artists.fetch(id: artistID)
-        }
         let nearby = await self.nearbyReleases(of: release, album: album, artist: artist)
 
         let ownedTracks = try await self.tracks.count(albumID: album.id ?? 0)
@@ -197,6 +204,7 @@ public actor DeepDiveService {
             releaseMBID: release.id,
             releaseGroupMBID: release.releaseGroup?.id ?? album.musicbrainzReleaseGroupID,
             releaseChosen: releaseChosen,
+            mbidGuessed: guessed,
             primaryType: release.releaseGroup?.primaryType,
             secondaryTypes: release.releaseGroup?.secondaryTypes ?? [],
             date: release.date,
@@ -243,7 +251,13 @@ public actor DeepDiveService {
     /// The recording report for a track. Requires a recording MBID on the row.
     public func trackReport(trackID: Int64, forceRefresh: Bool = false) async throws -> TrackReport {
         let track = try await self.tracks.fetch(id: trackID)
-        guard let mbid = track.musicbrainzRecordingID, !mbid.isEmpty else { throw DeepDiveError.noIdentifier }
+        var guessed = false
+        var resolved = track.musicbrainzRecordingID
+        if resolved == nil || resolved?.isEmpty == true {
+            resolved = try await self.guessRecordingMBID(track: track)
+            guessed = resolved != nil
+        }
+        guard let mbid = resolved, !mbid.isEmpty else { throw DeepDiveError.noIdentifier }
         let key = "recording-\(mbid)"
         let cached: (value: TrackReport, fresh: Bool)? = await self.cache.load(TrackReport.self, key: key)
         if let cached, cached.fresh, !forceRefresh { return cached.value }
@@ -269,6 +283,7 @@ public actor DeepDiveService {
             let report = TrackReport(
                 trackID: trackID,
                 recordingMBID: mbid,
+                mbidGuessed: guessed,
                 title: recording.title,
                 artistCredit: recording.artistName,
                 length: recording.length,
@@ -286,6 +301,38 @@ public actor DeepDiveService {
             if let cached { return cached.value }
             throw error
         }
+    }
+
+    // MARK: - Name-search fallbacks
+
+    /// Guesses the album's release group by a name search when the tags
+    /// supplied no release or release-group id. Only a match at or above
+    /// `guessScoreThreshold` is used; the report is flagged `mbidGuessed` and
+    /// nothing is persisted, because the album MBID columns are rolled up
+    /// from tracks by the scanner and a stored guess would not survive a
+    /// rescan.
+    private func guessReleaseGroupMBID(album: Album, artist: Artist?) async throws -> String? {
+        guard let artist else { return nil }
+        let title = album.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = artist.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty, !name.isEmpty else { return nil }
+        let results = try await self.mapErrors { try await self.musicBrainz.searchReleaseGroups(artist: name, album: title, limit: 5) }
+        guard let best = results.first, (best.score ?? 0) >= Self.guessScoreThreshold else { return nil }
+        self.log.info("deepdive.album.guessed", ["album": title, "mbid": best.id, "score": best.score ?? 0])
+        return best.id
+    }
+
+    /// Guesses the track's recording by an artist + title search, same rules.
+    private func guessRecordingMBID(track: Track) async throws -> String? {
+        guard let artistID = track.artistID,
+              let artist = try? await self.artists.fetch(id: artistID) else { return nil }
+        let title = (track.title ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = artist.name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty, !name.isEmpty else { return nil }
+        let results = try await self.mapErrors { try await self.musicBrainz.searchRecordings(artist: name, title: title, limit: 5) }
+        guard let best = results.first, (best.score ?? 0) >= Self.guessScoreThreshold else { return nil }
+        self.log.info("deepdive.track.guessed", ["track": title, "mbid": best.id, "score": best.score ?? 0])
+        return best.id
     }
 
     // MARK: - Errors

--- a/Modules/Library/Tests/LibraryTests/DeepDiveServiceTests.swift
+++ b/Modules/Library/Tests/LibraryTests/DeepDiveServiceTests.swift
@@ -64,6 +64,13 @@ private let recordingJSON = """
              {"id":"rel-b","title":"1967-1970","date":"1973","country":"US","status":"Official","release-group":{"id":"rg-red","primary-type":"Album","secondary-types":["Compilation"]}}]}
 """
 
+private let groupSearchJSON = """
+{"count":1,"release-groups":[{"id":"rg-abbey","score":100,"title":"Abbey Road","primary-type":"Album","first-release-date":"1969-09-26"}]}
+"""
+private let recordingSearchJSON = """
+{"count":1,"recordings":[{"id":"rec-1","score":100,"title":"Come Together","artist-credit":[{"name":"The Beatles"}]}]}
+"""
+
 private struct Bed {
     let db: Database
     let http: RoutingHTTP
@@ -78,6 +85,10 @@ private func makeBed(ttl: TimeInterval = 3600) async throws -> Bed {
         ("/ws/2/artist/\(beatlesMBID)?", artistJSON),
         ("/ws/2/artist?", searchJSON),
         ("/ws/2/release-group?artist=", browseJSON),
+        // The client sorts query keys ("limit" before "query"), so match on
+        // the query content, which is unique per search kind.
+        ("AND releasegroup:\"", groupSearchJSON),
+        ("AND recording:\"", recordingSearchJSON),
         ("/ws/2/recording/rec-1", recordingJSON),
         ("/ws/2/release/rel-a?", releaseJSON),
         ("/ws/2/release-group/rg-abbey?", groupLookupJSON),
@@ -252,6 +263,7 @@ struct DeepDiveServiceTests {
         #expect(report.title == "Abbey Road")
         #expect(report.releaseMBID == "rel-a")
         #expect(report.releaseChosen == false)
+        #expect(report.mbidGuessed == false)
         #expect(report.labels == [AlbumReport.Label(name: "Apple Records", catalogNumber: "PCS 7088")])
         #expect(report.formats == ["12\" Vinyl"])
         #expect(report.trackCount == 17)
@@ -276,5 +288,65 @@ struct DeepDiveServiceTests {
         #expect(report.releaseChosen)
         #expect(report.releaseMBID == "rel-a", "earliest official, not the 2019 reissue or the bootleg")
         #expect(bed.http.requests.contains { $0.contains("/ws/2/release-group/rg-abbey?") })
+    }
+
+    @Test("an album with no MusicBrainz ids at all is found by a confident name search and flagged guessed")
+    func albumReportGuessed() async throws {
+        let bed = try await makeBed()
+        let artist = try await ArtistRepository(database: bed.db).findOrCreate(name: "The Beatles", musicbrainzID: beatlesMBID)
+        let album = try await AlbumRepository(database: bed.db).findOrCreate(title: " Abbey Road ", albumArtistID: artist.id)
+
+        let report = try await bed.service.albumReport(albumID: #require(album.id))
+        #expect(report.mbidGuessed)
+        #expect(report.releaseChosen, "the guessed group still resolves to its earliest official release")
+        #expect(report.releaseMBID == "rel-a")
+        #expect(
+            bed.http.requests.contains { $0.contains("query=artist:\"The Beatles\" AND releasegroup:\"Abbey Road\"") },
+            "the search uses trimmed names"
+        )
+    }
+
+    @Test("a track with no recording id is found by a confident artist + title search and flagged guessed")
+    func trackReportGuessed() async throws {
+        let bed = try await makeBed()
+        let artist = try await ArtistRepository(database: bed.db).findOrCreate(name: "The Beatles", musicbrainzID: beatlesMBID)
+        let tracks = TrackRepository(database: bed.db)
+        let now = Int64(Date().timeIntervalSince1970)
+        var track = Track(
+            fileURL: "file:///tmp/ct3.flac",
+            fileSize: 1,
+            fileMtime: now,
+            fileFormat: "flac",
+            duration: 259,
+            title: " Come Together ",
+            addedAt: now,
+            updatedAt: now
+        )
+        track.artistID = artist.id
+        let id = try await tracks.upsert(track)
+
+        let report = try await bed.service.trackReport(trackID: id)
+        #expect(report.mbidGuessed)
+        #expect(report.recordingMBID == "rec-1")
+        #expect(report.title == "Come Together")
+        #expect(
+            bed.http.requests.contains { $0.contains("query=artist:\"The Beatles\" AND recording:\"Come Together\"") },
+            "the search uses trimmed names"
+        )
+    }
+
+    @Test("a name match below the confidence threshold is not used")
+    func lowScoreRejected() async throws {
+        let bed = try await makeBed()
+        bed.http.routes = bed.http.routes.map { route in
+            route.match == "AND releasegroup:\""
+                ? (route.match, #"{"count":1,"release-groups":[{"id":"rg-wrong","score":62,"title":"Abbey Roadhouse"}]}"#)
+                : route
+        }
+        let artist = try await ArtistRepository(database: bed.db).findOrCreate(name: "The Beatles")
+        let album = try await AlbumRepository(database: bed.db).findOrCreate(title: "Abbey Road", albumArtistID: artist.id)
+        await #expect(throws: DeepDiveError.noIdentifier) {
+            _ = try await bed.service.albumReport(albumID: #require(album.id))
+        }
     }
 }

--- a/Modules/UI/Sources/UI/DeepDive/DeepDiveAlbumView.swift
+++ b/Modules/UI/Sources/UI/DeepDive/DeepDiveAlbumView.swift
@@ -50,6 +50,11 @@ struct DeepDiveAlbumView: View {
 
     private func releaseSection(_ report: AlbumReport) -> some View {
         Section(L10n.string("Release")) {
+            if report.mbidGuessed {
+                Label(L10n.string("Matched by name; the tags carry no MusicBrainz id."), systemImage: "questionmark.circle")
+                    .font(Typography.caption)
+                    .foregroundStyle(Color.warningTint)
+            }
             if report.releaseChosen {
                 Label(
                     L10n.string("The tags name only the release group; showing its earliest official release."),

--- a/Modules/UI/Sources/UI/DeepDive/DeepDiveTrackView.swift
+++ b/Modules/UI/Sources/UI/DeepDive/DeepDiveTrackView.swift
@@ -51,6 +51,11 @@ struct DeepDiveTrackView: View {
 
     private func recordingSection(_ report: TrackReport) -> some View {
         Section(L10n.string("Recording")) {
+            if report.mbidGuessed {
+                Label(L10n.string("Matched by name; the tags carry no MusicBrainz id."), systemImage: "questionmark.circle")
+                    .font(Typography.caption)
+                    .foregroundStyle(Color.warningTint)
+            }
             LabeledContent(L10n.string("Title"), value: report.title)
             LabeledContent(L10n.string("Artist credit"), value: report.artistCredit)
             if let length = report.length {

--- a/Modules/UI/Tests/UITests/SnapshotTests/SnapshotTests+DeepDive.swift
+++ b/Modules/UI/Tests/UITests/SnapshotTests/SnapshotTests+DeepDive.swift
@@ -59,7 +59,7 @@ extension UISnapshotTests {
             let vm = try await DeepDiveAlbumViewModel(service: self.makeService(), albumID: 1)
             try vm.show(self.decode("""
             {"albumID":1,"title":"Abbey Road","artistName":"The Beatles","releaseMBID":"rel-a","releaseGroupMBID":"rg-abbey",
-             "releaseChosen":true,"primaryType":"Album","secondaryTypes":[],"date":"1969-09-26","country":"GB",
+             "releaseChosen":true,"mbidGuessed":false,"primaryType":"Album","secondaryTypes":[],"date":"1969-09-26","country":"GB",
              "status":"Official","barcode":"077774644624","labels":[{"name":"Apple Records","catalogNumber":"PCS 7088"}],
              "formats":["12\\" Vinyl"],"trackCount":17,"ownedTrackCount":17,
              "coverArtArchiveURL":"https://coverartarchive.org/release/rel-a","musicBrainzURL":"https://musicbrainz.org/release/rel-a",
@@ -74,7 +74,7 @@ extension UISnapshotTests {
         func trackReport() async throws {
             let vm = try await DeepDiveTrackViewModel(service: self.makeService(), trackID: 1)
             try vm.show(self.decode("""
-            {"trackID":1,"recordingMBID":"rec-1","title":"Come Together","artistCredit":"The Beatles","length":259000,
+            {"trackID":1,"recordingMBID":"rec-1","mbidGuessed":false,"title":"Come Together","artistCredit":"The Beatles","length":259000,
              "isrcs":["GBAYE0601690"],"firstReleaseYear":1969,"tags":["rock","pop"],
              "appearances":[{"releaseTitle":"Abbey Road","releaseMBID":"rel-a","year":1969,"country":"GB","status":"Official",
               "primaryType":"Album","secondaryTypes":[]},


### PR DESCRIPTION
## The bug

Get Info > Deep Dive on an album or song without MusicBrainz tags showed "No MusicBrainz identifier for this item, and no confident match by name", but no name match was ever attempted: only the artist path had a search fallback; `buildAlbumReport` and `trackReport` threw `noIdentifier` immediately. Reported with Lisa Gerrard / The Black Opal / The Messenger, where every row lacks MBIDs and MusicBrainz scores the name matches 100.

## The fix

- Albums fall back to `searchReleaseGroups(artist:album:)`, tracks to a new `searchRecordings(artist:title:)`, inputs trimmed (the reporter's track title carries a leading space), both gated on the existing `guessScoreThreshold` (90), mirroring the artist design.
- A guessed report shows the existing "Matched by name; the tags carry no MusicBrainz id." banner (reused catalog key, no new localization) via a new `mbidGuessed` flag on `AlbumReport`/`TrackReport`.
- Guesses are not persisted, matching the artist rule ("a guess is not persisted" until confirmed) and because the album MBID columns are scanner-owned rollups (`recomputeMusicBrainzIDs`) that a rescan would overwrite. A confirm flow for albums/tracks would need its own column ownership design; out of scope here.
- `MBReleaseGroup` search results now decode their Lucene `score` (the fixture already carried it).

## Tests

- Acoustics: `searchRecordings` decode + query shape (new fixture); score assertions added to the release-group search test.
- Library: album guessed by search (trimmed query asserted), track guessed by search, below-threshold match rejected with `noIdentifier`, `mbidGuessed == false` asserted on the tagged path. 388 Library tests green.
- UI snapshot fixtures gain `"mbidGuessed":false` so existing snapshots are unchanged.

Gates: format, lint, `make test-acoustics`, `make test-library`, `make build`, `make test-ui`, `make test-coverage` all green locally. One decoding caveat: cached Deep Dive reports from before this change fail to decode against the new field and are refetched once; the cache treats a failed decode as a miss by design.