### PR TITLE
chore(release): 2.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.13.0](https://github.com/bocan/bocan-music/compare/v2.12.0...v2.13.0) (2026-09-02)
+
 Phone Sync can now shrink your music on the way to the phone. Pick a quality in Settings, from MP3 320 down to Opus 128, and anything bigger is converted before it syncs, so a lossless library fits in a fraction of the space. Each choice shows what your selection would cost the phone in storage, a progress line follows the conversion as it runs ahead of the sync, and your files on the Mac are never touched. Converted copies are made just in time and cleaned up once the phone has them, so the Mac does not fill up either: conversion stays a few gigabytes ahead of the phone, and the progress line says so while the next batch waits. A switch keeps the copies around if you would rather re-sync instantly, and with it on the whole selection converts up front.
+
+### For developers
+
+**Added**
+- sync: transcode to MP3/Opus for Phone Sync (ADR-088) ([#437](https://github.com/bocan/bocan-music/pull/437))
 
 ## [2.12.0](https://github.com/bocan/bocan-music/compare/v2.11.0...v2.12.0) (2026-08-31)
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.12.0</string>
+    <string>2.13.0</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Cut by the Release workflow. Merging tags v2.13.0 and publishes it.

---

Phone Sync can now shrink your music on the way to the phone. Pick a quality in Settings, from MP3 320 down to Opus 128, and anything bigger is converted before it syncs, so a lossless library fits in a fraction of the space. Each choice shows what your selection would cost the phone in storage, a progress line follows the conversion as it runs ahead of the sync, and your files on the Mac are never touched. Converted copies are made just in time and cleaned up once the phone has them, so the Mac does not fill up either: conversion stays a few gigabytes ahead of the phone, and the progress line says so while the next batch waits. A switch keeps the copies around if you would rather re-sync instantly, and with it on the whole selection converts up front.

Full changelog: https://github.com/bocan/bocan-music/compare/v2.12.0...v2.13.0