### PR TITLE
ci(release): attest build provenance for the DMG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -164,6 +164,15 @@ jobs:
       (needs.prepare.result == 'success' || (needs.prepare.result == 'skipped' && inputs.tag != ''))
     runs-on: macos-26
 
+    # id-token + attestations let actions/attest-build-provenance sign a
+    # SLSA provenance statement for the DMG with a short-lived Sigstore
+    # certificate tied to this job's OIDC identity. Scoped to this job only;
+    # prepare never needs them.
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
     # arm64-only: Bòcan targets Apple Silicon (macOS 15+). Intel Macs are not
     # supported because the bundled FFmpeg dylibs and fpcalc binary in Resources/
     # are arm64-only. A universal binary would require rebuilding those as fat
@@ -463,6 +472,18 @@ jobs:
           shasum -a 256 Bocan.dmg | tee Bocan.dmg.sha256
           SHA256=$(awk '{print $1}' Bocan.dmg.sha256)
           echo "sha256=$SHA256" >> "$GITHUB_OUTPUT"
+
+      # Build provenance: a signed SLSA statement, stored by GitHub (not as a
+      # release asset), that ties the final notarized DMG's digest to this
+      # repo, commit, workflow and run. Developer ID + notarization prove who
+      # signed the DMG; this proves it was built here from this tag. Anyone
+      # can check a download with:
+      #   gh attestation verify Bocan.dmg --repo bocan/bocan-music
+      # Runs after stapling so the attested digest is the one users download.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v4
+        with:
+          subject-path: build/Bocan.dmg
 
       - name: Release notes (users only) from CHANGELOG
         id: notes

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -142,7 +142,9 @@ are written before the release exists, one PR at a time:
    - builds, signs, notarizes, packages the DMG, and publishes the GitHub
      release with the prose only (`Scripts/release-notes.sh`) plus a "Full
      changelog" link, uploading the DMG, its checksum and the signed
-     `appcast-entry.xml`;
+     `appcast-entry.xml`, and records a build-provenance attestation for the
+     DMG (Sigstore-signed, stored on the repo's Attestations page, verifiable
+     with `gh attestation verify Bocan.dmg --repo bocan/bocan-music`);
    - pings the Homebrew tap. The Website workflow then assembles the Sparkle
      feed from every release's `appcast-entry.xml` (`Scripts/build-appcast.sh`)
      on top of the frozen history in `website/appcast/` and redeploys the site.

--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Contributions and ideas welcome. Open an issue or a pull request.
 
 **Download the DMG** from [bocan.app/download](https://bocan.app/download) or the [GitHub Releases](https://github.com/bocan/bocan-music/releases) page. Open it, drag Bòcan to Applications, done.
 
+**Verify a download** (optional). Every DMG is signed with a Developer ID and notarized by Apple, and the release workflow also publishes a signed build attestation that ties the exact file to the commit and workflow run that built it. With the [GitHub CLI](https://cli.github.com) installed:
+
+```bash
+gh attestation verify Bocan.dmg --repo bocan/bocan-music
+```
+
+The command fails if the file was altered or was not built by this repository's release workflow.
+
 **Homebrew**: add the tap once, then install:
 
 ```bash

--- a/docs/design-spec/ADR-033-trunk-based-cicd.md
+++ b/docs/design-spec/ADR-033-trunk-based-cicd.md
@@ -65,7 +65,7 @@ process:
 | `pr.yml` | pull request to `main` | `changes` job diffs the PR; docs-only PRs skip the rest. Otherwise the full suite: `make test-coverage` + SPM package tests | done, slice 2 |
 | `pr-metadata.yml` | pull request opened/edited/synchronize/labeled | Conventional Commit title check; `feat`/`fix`/`perf` must add a line under `## [Unreleased]` in `CHANGELOG.md` unless labelled `skip-changelog` | done, slice 2 |
 | Snyk (GitHub app, no file) | pull request | dependency manifest scan | existing, keep |
-| `release.yml` | manual only (`workflow_dispatch`, optional `tag` to rebuild) | `prepare` (Linux): `Scripts/release.sh` decides the version and rewrites `CHANGELOG.md` + `Info.plist`, lands them as a `chore(release): X.Y.Z` PR through the normal checks, tags the merge. `build` (macOS): tests, sign, notarize, DMG, GitHub release with prose-only notes, `appcast-entry.xml` asset, cask dispatch | done, slice 3 |
+| `release.yml` | manual only (`workflow_dispatch`, optional `tag` to rebuild) | `prepare` (Linux): `Scripts/release.sh` decides the version and rewrites `CHANGELOG.md` + `Info.plist`, lands them as a `chore(release): X.Y.Z` PR through the normal checks, tags the merge. `build` (macOS): tests, sign, notarize, DMG, build-provenance attestation of the DMG, GitHub release with prose-only notes, `appcast-entry.xml` asset, cask dispatch | done, slice 3 |
 | `website.yml` | push to `main` touching `website/**` or `CHANGELOG.md`, after a Release run | `Scripts/build-appcast.sh` assembles the Sparkle feeds from `website/appcast/seed*.xml` plus every later release's asset; Eleventy build; Pages deploy | reworked, slice 3 |
 | `dependency-drift.yml` | weekly cron | pin drift report as an issue | existing, keep |
 


### PR DESCRIPTION
## Summary

Adds a GitHub artifact attestation to the release pipeline. Every release now records a Sigstore-signed SLSA provenance statement that ties the notarized Bocan.dmg digest to the tag, workflow file and run that built it.

- `actions/attest-build-provenance@v4` runs on `build/Bocan.dmg` after notarization and stapling, so the attested digest is the one users download.
- `id-token: write` and `attestations: write` are scoped to the `build` job only. The `prepare` job keeps the top-level `contents: write`.
- README gains a short "Verify a download" note; DEVELOPMENT.md and ADR-033 mention the new step.

Developer ID signing and notarization prove who signed the DMG. The attestation proves it was built here from this tag, and it is stored by GitHub rather than as a release asset, so it cannot be swapped alongside the DMG.

## Verify

After the next release run, the repo's Attestations page should list Bocan.dmg, and this should pass on the downloaded file:

```bash
gh attestation verify Bocan.dmg --repo bocan/bocan-music
```

## Checks

- `make lint` and `make format` pass. No Swift changes, so no build or test run.
- actionlint reports three pre-existing shellcheck style notes on untouched lines; they also fire on main.
- No CHANGELOG entry: CI-only change, not visible in the app.