### PR TITLE
chore(release): 2.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.0](https://github.com/bocan/bocan-music/compare/v2.13.0...v2.14.0) (2026-09-05)
+
 Experimental: Immersive Mode. Press Shift-Command-I, pick View, Enter Immersive Mode, or click the new three-column button in the toolbar, and Bòcan opens a full-screen window with nothing on it but the music: the oscilloscope running edge to edge in the Drift palette, and three cards over it with the artwork, title and player controls, the next ten songs in your queue (scroll for the rest), and the lyrics, synced where you have them. Esc brings you back. It is marked experimental on purpose: the visualizer behind the cards is heavier than the one in the side pane, and if it turns out to stutter on too many Macs the mode may change shape or be removed in a later update.
 
 Phone Sync conversion no longer takes the whole app down on a file whose sound switches between stereo and mono part way through, which some damaged MP3s do. The converter now adapts mid-file and carries on, so a single odd track cannot stop every sync.
+
+### For developers
+
+**Added**
+- ui: Immersive Mode, an experimental full-screen now-playing window (ADR-089) ([#444](https://github.com/bocan/bocan-music/pull/444))
+
+**Fixed**
+- audio: rebuild the transcode resampler when a frame's shape changes ([#443](https://github.com/bocan/bocan-music/pull/443))
 
 ## [2.13.0](https://github.com/bocan/bocan-music/compare/v2.12.0...v2.13.0) (2026-09-02)
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.13.0</string>
+    <string>2.14.0</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Cut by the Release workflow. Merging tags v2.14.0 and publishes it.

---

Experimental: Immersive Mode. Press Shift-Command-I, pick View, Enter Immersive Mode, or click the new three-column button in the toolbar, and Bòcan opens a full-screen window with nothing on it but the music: the oscilloscope running edge to edge in the Drift palette, and three cards over it with the artwork, title and player controls, the next ten songs in your queue (scroll for the rest), and the lyrics, synced where you have them. Esc brings you back. It is marked experimental on purpose: the visualizer behind the cards is heavier than the one in the side pane, and if it turns out to stutter on too many Macs the mode may change shape or be removed in a later update.

Phone Sync conversion no longer takes the whole app down on a file whose sound switches between stereo and mono part way through, which some damaged MP3s do. The converter now adapts mid-file and carries on, so a single odd track cannot stop every sync.

Full changelog: https://github.com/bocan/bocan-music/compare/v2.13.0...v2.14.0