### PR TITLE
fix(sync): re-encode a released transcode artifact on an urgent request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.
+
 ## [2.14.0](https://github.com/bocan/bocan-music/compare/v2.13.0...v2.14.0) (2026-09-05)
 
 Experimental: Immersive Mode. Press Shift-Command-I, pick View, Enter Immersive Mode, or click the new three-column button in the toolbar, and Bòcan opens a full-screen window with nothing on it but the music: the oscilloscope running edge to edge in the Drift palette, and three cards over it with the artwork, title and player controls, the next ten songs in your queue (scroll for the rest), and the lyrics, synced where you have them. Esc brings you back. It is marked experimental on purpose: the visualizer behind the cards is heavier than the one in the side pane, and if it turns out to stutter on too many Macs the mode may change shape or be removed in a later update.

--- a/Modules/SyncServer/Sources/SyncServer/Transcode/TranscodeCoordinator.swift
+++ b/Modules/SyncServer/Sources/SyncServer/Transcode/TranscodeCoordinator.swift
@@ -309,20 +309,31 @@ public actor TranscodeCoordinator {
     /// the window: the user opted into the disk cost, so the whole selection
     /// prepares up front. One failed file logs and moves on; only
     /// cancellation stops the pass.
+    ///
+    /// An urgent request for a track whose row is valid but whose bytes were
+    /// released (the 503-busy self-heal of ADR-088) re-encodes that track
+    /// too: the row stays advertised, the upsert clears `served_at`, and the
+    /// phone's retry finds the artifact. Urgent work also passes a full
+    /// window, because the phone is waiting on it right now.
     private func encodeMissing(
         targets: [Track],
         valid: [SyncTranscode],
         preset: TranscodePreset,
         ignoreWindow: Bool
     ) async throws {
+        let urgent = self.urgentTrackIDs
+        self.urgentTrackIDs.removeAll()
         let validIDs = Set(valid.map(\.trackID))
+        let released = Set(valid.lazy
+            .filter { urgent.contains($0.trackID) }
+            .filter { !self.store.exists(trackID: $0.trackID, sourceContentHash: $0.sourceContentHash, preset: preset) }
+            .map(\.trackID))
         var pending = targets.filter { track in
-            guard let id = track.id, let hash = track.contentHash, !validIDs.contains(id) else { return false }
+            guard let id = track.id, let hash = track.contentHash else { return false }
+            guard !validIDs.contains(id) || released.contains(id) else { return false }
             let memo = FailedEncode(trackID: id, preset: preset.rawValue, sourceContentHash: hash)
             return !self.failedEncodes.contains(memo)
         }
-        let urgent = self.urgentTrackIDs
-        self.urgentTrackIDs.removeAll()
         pending.sort { lhs, rhs in
             let lhsUrgent = lhs.id.map { urgent.contains($0) } ?? false
             let rhsUrgent = rhs.id.map { urgent.contains($0) } ?? false
@@ -330,6 +341,9 @@ public actor TranscodeCoordinator {
             return (lhs.id ?? 0) < (rhs.id ?? 0)
         }
         guard !pending.isEmpty else { return }
+        if !released.isEmpty {
+            self.log.debug("transcode.reencode.released", ["count": "\(released.count)", "preset": preset.rawValue])
+        }
 
         var unservedBytes = valid
             .filter { $0.servedAt == nil }
@@ -344,11 +358,13 @@ public actor TranscodeCoordinator {
             // stop() cancels the pass's task, so cancellation is the one
             // mid-pass exit; a direct runPass() in tests runs to completion.
             try Task.checkCancellation()
-            if !ignoreWindow, unservedBytes >= self.prepareWindowBytes {
+            guard let id = track.id, let sourceHash = track.contentHash else { continue }
+            // Urgent tracks sort first, so the first non-urgent track is where
+            // a full window parks the pass.
+            if !ignoreWindow, !urgent.contains(id), unservedBytes >= self.prepareWindowBytes {
                 self.log.debug("transcode.window.full", ["bytes": "\(unservedBytes)"])
                 break
             }
-            guard let id = track.id, let sourceHash = track.contentHash else { continue }
             do {
                 let result = try await self.encodeOne(
                     track,

--- a/Modules/SyncServer/Tests/SyncServerTests/TranscodeCoordinatorTests.swift
+++ b/Modules/SyncServer/Tests/SyncServerTests/TranscodeCoordinatorTests.swift
@@ -324,6 +324,77 @@ struct TranscodeCoordinatorTests {
         try self.cleanup(fixture)
     }
 
+    @Test("an urgent request for released bytes re-encodes and clears the served stamp")
+    func urgentReencodesReleasedBytes() async throws {
+        let fixture = try await makeFixture()
+        let id = try await insertTrack(fixture, title: "L", contentHash: "h1", isLossless: true)
+        try await self.setDocument(fixture, preset: .opus128)
+        await fixture.coordinator.runPass()
+
+        // Served, then swept: the row stays, the bytes go.
+        try await fixture.ledger.stampServed(trackID: id, preset: "opus_128", at: 1_756_000_000)
+        await fixture.coordinator.runPass()
+        #expect(!fixture.store.exists(trackID: id, sourceContentHash: "h1", preset: .opus128))
+
+        // The phone asks again (the 503-busy path) and the next pass heals it.
+        await fixture.coordinator.requestUrgent(trackID: id)
+        await fixture.coordinator.runPass()
+
+        #expect(fixture.encoder.encodeCount == 2)
+        #expect(fixture.store.exists(trackID: id, sourceContentHash: "h1", preset: .opus128))
+        let row = try #require(try await fixture.ledger.allValid(preset: "opus_128").first)
+        #expect(row.trackID == id)
+        #expect(row.servedAt == nil, "a fresh artifact must survive the next release sweep")
+
+        // The following pass leaves the fresh bytes alone.
+        await fixture.coordinator.runPass()
+        #expect(fixture.encoder.encodeCount == 2)
+        #expect(fixture.store.exists(trackID: id, sourceContentHash: "h1", preset: .opus128))
+
+        try self.cleanup(fixture)
+    }
+
+    @Test("an urgent request for bytes still on disk does not re-encode")
+    func urgentWithPresentBytesIsNoop() async throws {
+        let fixture = try await makeFixture()
+        let id = try await insertTrack(fixture, title: "L", contentHash: "h1", isLossless: true)
+        try await self.setDocument(fixture, preset: .opus128)
+        await fixture.coordinator.runPass()
+
+        await fixture.coordinator.requestUrgent(trackID: id)
+        await fixture.coordinator.runPass()
+
+        #expect(fixture.encoder.encodeCount == 1)
+
+        try self.cleanup(fixture)
+    }
+
+    @Test("an urgent re-encode passes a full prepare window")
+    func urgentPassesFullWindow() async throws {
+        let fixture = try await makeFixture(prepareWindowBytes: 100)
+        let first = try await insertTrack(fixture, title: "A", contentHash: "h-a", isLossless: true)
+        let second = try await insertTrack(fixture, title: "B", contentHash: "h-b", isLossless: true)
+        try await self.setDocument(fixture, preset: .opus128)
+
+        // First pass fills the window with A; B parks.
+        await fixture.coordinator.runPass()
+        #expect(fixture.encoder.encodedTrackIDs == [first])
+
+        // A is served and swept, B gets encoded and now fills the window.
+        try await fixture.ledger.stampServed(trackID: first, preset: "opus_128", at: 1_756_000_000)
+        await fixture.coordinator.runPass()
+        #expect(fixture.encoder.encodedTrackIDs == [first, second])
+        #expect(!fixture.store.exists(trackID: first, sourceContentHash: "h-a", preset: .opus128))
+
+        // The phone lost A and asks again: the window is full of B, yet A re-encodes.
+        await fixture.coordinator.requestUrgent(trackID: first)
+        await fixture.coordinator.runPass()
+        #expect(fixture.encoder.encodedTrackIDs == [first, second, first])
+        #expect(fixture.store.exists(trackID: first, sourceContentHash: "h-a", preset: .opus128))
+
+        try self.cleanup(fixture)
+    }
+
     @Test("ledger writes bump the sync generation through the observed tables")
     func ledgerWritesBumpGeneration() async throws {
         let fixture = try await makeFixture()


### PR DESCRIPTION
## Summary

Refs #378 (the stuck-tracks report in the comments).

A transcoded track whose ledger row was valid but whose bytes had been released after a completed transfer answered 503 busy forever. FileServing called requestUrgent as designed, but the coordinator only used the urgent list to reorder its queue, and encodeMissing skipped every track that already had a valid row. So the self-heal path in ADR-088 never actually re-encoded anything.

A phone that lost a file mid-transfer (Android battery optimisation killing the sync after the Mac had already written the last bytes to the socket) retried on every run and stayed pending, which matches the seven tracks in the report.

## Changes

- The pass now re-encodes an urgent track whose artifact is missing even though its row is valid. The upsert clears served_at, so the next release sweep keeps the fresh bytes.
- Urgent work passes a full prepare window, because the phone is waiting on it.
- Tests: released bytes re-encode on an urgent request and survive the next sweep; present bytes do not re-encode; an urgent re-encode passes a full window.
- CHANGELOG Unreleased note.

## Follow-up (Android repo)

The phone treats a 503 on a file download as a hard per-item failure with no wait, against sync-protocol.md section 6. With this fix alone the phone needs one extra sync to pick the file up; honouring Retry-After on file requests would make it happen in the same run.

## Gates

make format, make lint, make build, make test-sync-server (127 tests), make test-coverage all green.