### PR TITLE
chore(deps): bump swift-certificates 1.20.0, swift-crypto 4.5.2, swift-asn1 1.7.2

### DIFF
--- a/Bocan.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Bocan.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc0c2dab133abfc9b62dbe02b1ab2c39e3617e19d42c0ea9a57f676991df3228",
+  "originHash" : "a475ccb134a09d8925ffa114cca29dc25699b8cda33da964495602035149ab00",
   "pins" : [
     {
       "identity" : "feedkit",
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
-        "version" : "1.7.1"
+        "revision" : "d9a5b37470adc940d22c3bcd5ca6953a516b727f",
+        "version" : "1.7.2"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-certificates.git",
       "state" : {
-        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
-        "version" : "1.19.4"
+        "revision" : "c8aece90ea05f9866bd392a5bf13b5cae56c0e03",
+        "version" : "1.20.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
-        "version" : "4.5.1"
+        "revision" : "da9d28d69ebe3894b18376c8f2395c2f37b8448f",
+        "version" : "4.5.2"
       }
     },
     {

--- a/Modules/SyncServer/Package.swift
+++ b/Modules/SyncServer/Package.swift
@@ -17,9 +17,9 @@ let package = Package(
         .package(path: "../Library"),
         .package(path: "../Metadata"),
         .package(path: "../Podcasts"),
-        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.19.4"),
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.1"),
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-certificates.git", from: "1.20.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "4.5.2"),
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.7.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Closes #447

## Summary

Moves the three Apple security packages to their latest minor or patch releases. Floors bumped in the SyncServer manifest; workspace pins moved together. No other pin changed.

## Breaking-change check

- swift-certificates 1.20.0: one change, a CMSSignerInfo unsignedAttrs tag fix in the CMS module (hence the minor label). This app uses X509 only (Certificate, DER, KeyUsage, BasicConstraints); CMS is never imported.
- swift-crypto 4.5.2: RSA key size derived from modulus length, and a 2048-bit minimum on RSA raw initializers. This app uses P-256 only.
- swift-asn1 1.7.2: throws on truncated BER indefinite lengths. This app uses DER only.

## Gates

Every make test-<module> target, make build and make test-coverage green. One UI test (NowPlayingRadioRestoreTests, a real-time wait test) flaked under full parallel load and passed alone; unrelated to these packages.

Not user-visible, so no changelog entry.