### PR TITLE
fix(ui): keep the playback position tick out of the root body and the songs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes.
+
 Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.
 
 This release pairs with Bòcan Music for Android 0.4.0, which carries the phone side of that fix: the phone now waits while the Mac converts the song again instead of giving up on it until the next sync. Install it from https://github.com/bocan/bocan-music-android/releases/tag/v0.4.0 so both ends match.

--- a/Modules/UI/Sources/UI/AppRoot/RootView.swift
+++ b/Modules/UI/Sources/UI/AppRoot/RootView.swift
@@ -118,7 +118,11 @@ public struct BocanRootView: View {
             if self.visualizerVM.paneVisible {
                 VisualizerPane(vm: self.visualizerVM, nowPlayingVM: self.vm.nowPlaying)
             } else {
-                LyricsPane(vm: self.lyricsVM, position: self.vm.nowPlaying.position) { pos in
+                // Pass the model, never `nowPlaying.position`: a position read
+                // here makes this whole body a dependent of the 0.5 s tick, and
+                // every child that cannot prove itself unchanged re-runs with it,
+                // down to the songs table re-diffing every row (#450).
+                LyricsPane(vm: self.lyricsVM, nowPlaying: self.vm.nowPlaying) { pos in
                     Task { await self.vm.nowPlaying.scrub(to: pos) }
                 }
             }

--- a/Modules/UI/Sources/UI/Lyrics/LyricsPane.swift
+++ b/Modules/UI/Sources/UI/Lyrics/LyricsPane.swift
@@ -12,8 +12,11 @@ public struct LyricsPane: View {
 
     @ObservedObject public var vm: LyricsViewModel
 
-    /// Current engine position, forwarded to ``LyricsView`` for line highlight.
-    public var position: TimeInterval
+    /// The transport model. Held as a plain reference: `@Observable` tracking
+    /// is per property, and the only property read here is `position`, inside
+    /// the editor sheet's content, so the 0.5 s position tick invalidates the
+    /// sheet content alone, never this pane and never `BocanRootView` (#450).
+    public var nowPlaying: NowPlayingViewModel
 
     /// Seek callback forwarded to ``LyricsView`` when the user taps a synced line.
     public var onSeek: (TimeInterval) -> Void
@@ -31,11 +34,11 @@ public struct LyricsPane: View {
 
     public init(
         vm: LyricsViewModel,
-        position: TimeInterval,
+        nowPlaying: NowPlayingViewModel,
         onSeek: @escaping (TimeInterval) -> Void
     ) {
         self.vm = vm
-        self.position = position
+        self.nowPlaying = nowPlaying
         self.onSeek = onSeek
     }
 
@@ -50,10 +53,10 @@ public struct LyricsPane: View {
                     self.searchBar
                     Divider()
                 }
-                // Line highlight is driven from BocanRootView, which forwards
-                // the engine position to the view model whether or not this
-                // pane is on screen (ADR-089: the Immersive Mode lyrics column
-                // shares the same document and needs the same ticks).
+                // Line highlight is driven by LyricsPlaybackDriver at the root,
+                // which forwards the engine position to the view model whether
+                // or not this pane is on screen (ADR-089: the Immersive Mode
+                // lyrics column shares the same document and needs the same ticks).
                 LyricsView(vm: self.vm, onSeek: self.onSeek, searchText: self.searchText)
             }
             .frame(width: self.paneWidth)
@@ -88,10 +91,13 @@ public struct LyricsPane: View {
                 }
             }
             .sheet(isPresented: self.$vm.isEditorPresented) {
+                // The one position read in this file. It runs while the sheet
+                // is up, inside the sheet's own content, so the tick reaches
+                // nothing else.
                 LyricsEditorSheet(
                     vm: self.vm,
                     isPresented: self.$vm.isEditorPresented,
-                    currentPosition: self.position
+                    currentPosition: self.nowPlaying.position
                 )
             }
             .accessibilityIdentifier(A11y.Lyrics.pane)

--- a/Modules/UI/Sources/UI/Lyrics/LyricsPlaybackDriver.swift
+++ b/Modules/UI/Sources/UI/Lyrics/LyricsPlaybackDriver.swift
@@ -8,8 +8,12 @@ import SwiftUI
 /// Applied once, at the root of the main window, not inside the lyrics pane,
 /// so every surface that shows the document sees the same highlight whether
 /// or not the pane is on screen: the pane, and the Immersive Mode lyrics
-/// column (ADR-089). The root body already reads the position for the pane,
-/// so this adds no new observation.
+/// column (ADR-089).
+///
+/// This modifier is the only reader of `position` at the root. A modifier's
+/// body is its own graph node, so the 0.5 s tick re-evaluates this small
+/// chain and not `BocanRootView.body` (#450); keep position reads out of
+/// the root body itself.
 struct LyricsPlaybackDriver: ViewModifier {
     let lyricsVM: LyricsViewModel
     let nowPlaying: NowPlayingViewModel

--- a/Modules/UI/Sources/UI/Lyrics/LyricsViewModel.swift
+++ b/Modules/UI/Sources/UI/Lyrics/LyricsViewModel.swift
@@ -156,9 +156,17 @@ public final class LyricsViewModel: ObservableObject {
     }
 
     /// Updates `currentLineIndex` from the engine's playback position.
+    ///
+    /// Called on every 0.5 s position tick. A `@Published` assignment emits
+    /// `objectWillChange` even when the value is unchanged, and every
+    /// `@ObservedObject` / `@EnvironmentObject` consumer of this model (the
+    /// root view, the tracks view) re-renders on each emission, so this must
+    /// publish only when the index actually moves (#450).
     public func positionDidChange(_ position: TimeInterval) {
         guard case let .synced(lines, offsetMS) = document, !lines.isEmpty else {
-            self.currentLineIndex = nil
+            if self.currentLineIndex != nil {
+                self.currentLineIndex = nil
+            }
             return
         }
 

--- a/Modules/UI/Tests/UITests/LyricsPositionPublishTests.swift
+++ b/Modules/UI/Tests/UITests/LyricsPositionPublishTests.swift
@@ -1,0 +1,95 @@
+import Combine
+import Foundation
+import Library
+import Metadata
+import Persistence
+import Testing
+@testable import UI
+
+// MARK: - LyricsPositionPublishTests
+
+/// #450: `LyricsViewModel.positionDidChange` runs on every 0.5 s playback tick.
+/// A `@Published` assignment emits `objectWillChange` even when the value is
+/// unchanged, and every `@ObservedObject` / `@EnvironmentObject` consumer of the
+/// model (the root view, the tracks view) re-renders on each emission, which
+/// ends in the songs table re-diffing every row twice a second. The model must
+/// publish from a tick only when the highlighted line actually moves.
+@Suite("LyricsViewModel publishes from a position tick only on a line change")
+@MainActor
+struct LyricsPositionPublishTests {
+    private func seedSynced(db: Database) async throws -> Int64 {
+        let now = Int64(Date().timeIntervalSince1970)
+        let trackID = try await TrackRepository(database: db).upsert(Track(
+            fileURL: "/tmp/publish.flac",
+            fileSize: 0,
+            fileMtime: 0,
+            fileFormat: "flac",
+            duration: 60,
+            addedAt: now,
+            updatedAt: now
+        ))
+        try await LyricsRepository(database: db).save(Lyrics(
+            trackID: trackID,
+            lyricsText: "[00:10.00]One\n[00:20.00]Two",
+            isSynced: true,
+            source: "user",
+            offsetMS: 0
+        ))
+        return trackID
+    }
+
+    private func waitUntil(_ condition: @escaping () -> Bool) async {
+        for _ in 0 ..< 100 where !condition() {
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    @Test("no document: repeated ticks never publish")
+    func noDocumentTicksAreSilent() async throws {
+        let db = try await Database(location: .inMemory)
+        let vm = LyricsViewModel(service: LyricsService(database: db, fetcher: nil))
+        var emissions = 0
+        let sink = vm.objectWillChange.sink { emissions += 1 }
+        defer { sink.cancel() }
+
+        for tick in 0 ..< 10 {
+            vm.positionDidChange(TimeInterval(tick) * 0.5)
+        }
+
+        #expect(emissions == 0, "an unsynced tick republished an unchanged nil index")
+        #expect(vm.currentLineIndex == nil)
+    }
+
+    @Test("synced document: ticks publish once per line change and not otherwise")
+    func syncedTicksPublishOnlyOnLineChange() async throws {
+        let db = try await Database(location: .inMemory)
+        let trackID = try await self.seedSynced(db: db)
+        let vm = LyricsViewModel(service: LyricsService(database: db, fetcher: nil))
+        vm.trackDidChange(trackID: trackID)
+        await self.waitUntil { vm.document != nil }
+        try #require(vm.document != nil)
+
+        var emissions = 0
+        let sink = vm.objectWillChange.sink { emissions += 1 }
+        defer { sink.cancel() }
+
+        // Before line one: index stays nil, nothing to publish.
+        for tick in 0 ..< 4 {
+            vm.positionDidChange(TimeInterval(tick) * 0.5)
+        }
+        #expect(emissions == 0)
+
+        // Crossing into line one publishes once; holding there publishes nothing.
+        vm.positionDidChange(10.2)
+        #expect(vm.currentLineIndex == 0)
+        #expect(emissions == 1)
+        vm.positionDidChange(10.7)
+        vm.positionDidChange(11.2)
+        #expect(emissions == 1)
+
+        // Line two: one more.
+        vm.positionDidChange(20.3)
+        #expect(vm.currentLineIndex == 1)
+        #expect(emissions == 2)
+    }
+}

--- a/Modules/UI/Tests/UITests/RootPositionTickConventionTests.swift
+++ b/Modules/UI/Tests/UITests/RootPositionTickConventionTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import UI
+
+// MARK: - RootPositionTickConventionTests
+
+/// Source-convention checks for #450: the 0.5 s playback position tick must not
+/// invalidate `BocanRootView.body`. A `nowPlaying.position` read in the root
+/// body makes the whole body a dependent of the tick, every child that cannot
+/// prove itself unchanged re-runs with it, and the songs table re-diffs every
+/// row twice a second (measured: 77 hitches over 100 ms in 45 s). Observation
+/// scope cannot be exercised host-less, so these assert the wiring.
+@Suite("Root position tick source conventions")
+struct RootPositionTickConventionTests {
+    private func source(_ relativePath: String) throws -> String {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent() // UITests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // Modules/UI/
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    /// Lines of code only: comments explaining the rule may name the property.
+    private func codeLines(_ source: String) -> [String] {
+        source.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0) }
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+    }
+
+    @Test("BocanRootView.body never reads nowPlaying.position")
+    func rootBodyDoesNotReadPosition() throws {
+        let source = try self.source("Sources/UI/AppRoot/RootView.swift")
+        let offenders = self.codeLines(source).filter { $0.contains("nowPlaying.position") }
+        #expect(offenders.isEmpty, "root body reads the position tick: \(offenders)")
+    }
+
+    @Test("LyricsPane takes the transport model, not a position value")
+    func lyricsPaneTakesModel() throws {
+        let source = try self.source("Sources/UI/Lyrics/LyricsPane.swift")
+        #expect(source.contains("nowPlaying: NowPlayingViewModel"))
+        #expect(!self.codeLines(source).contains { $0.contains("position: TimeInterval") })
+    }
+
+    @Test("LyricsPane reads the position only inside the editor sheet content")
+    func lyricsPanePositionReadIsInsideSheet() throws {
+        let source = try self.source("Sources/UI/Lyrics/LyricsPane.swift")
+        let reads = self.codeLines(source).filter { $0.contains("nowPlaying.position") }
+        #expect(reads.count == 1, "expected exactly one position read: \(reads)")
+        let sheet = try #require(source.range(of: ".sheet(isPresented: self.$vm.isEditorPresented)"))
+        let read = try #require(source.range(of: "currentPosition: self.nowPlaying.position"))
+        #expect(sheet.lowerBound < read.lowerBound)
+    }
+
+    @Test("LyricsPlaybackDriver still forwards each position tick to the lyrics model")
+    func driverForwardsPosition() throws {
+        let source = try self.source("Sources/UI/Lyrics/LyricsPlaybackDriver.swift")
+        #expect(source.contains(".onChange(of: self.nowPlaying.position)"))
+        #expect(source.contains("self.lyricsVM.positionDidChange(position)"))
+    }
+}

--- a/Modules/UI/Tests/UITests/ViewModelTests/ArtworkLoaderTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/ArtworkLoaderTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CoreGraphics
 import Foundation
 import ImageIO
@@ -11,14 +12,36 @@ import UniformTypeIdentifiers
 /// resolution (up to 4096px) regardless of display size and had no
 /// `totalCostLimit`, so 200 large covers could exceed 1 GB. `ArtworkLoader` now
 /// downsamples via `CGImageSource` to a capped, display-sized thumbnail.
-/// Main-actor: `NSImage` construction on a worker thread races AppKit's
-/// application-context `dispatch_once` under the parallel runner and can
-/// deadlock against a main-actor suite creating a window (it wedged two full
-/// `make tests` runs on 2026-09-01, in `-[NSApplication init]`). AppKit
-/// object creation belongs on main.
+/// `NSImage` construction on a worker thread races AppKit's application-context
+/// `dispatch_once` under the parallel runner and deadlocks against a main-actor
+/// suite creating a window (`WindowFadeTests`): it wedged two full `make tests`
+/// runs on 2026-09-01 and two `make test-ui` runs on 2026-09-07, in
+/// `-[NSApplication init]`. Marking the suite `@MainActor` is not enough:
+/// `ArtworkLoader` is an actor, so `await loader.image(...)` hops to the
+/// cooperative pool and builds the `NSImage` there. The `init` below runs on
+/// main (the suite is main-actor) and walks the same `NSImage(cgImage:)` path
+/// once, so AppKit's application context is initialised on main before any
+/// test awaits the loader, the order the app guarantees at launch. It must
+/// not touch `NSApplication`: the Xcode `BocanTests` bundle is host-less and
+/// that fails there.
 @MainActor
 @Suite("ArtworkLoader")
 struct ArtworkLoaderTests {
+    init() {
+        let context = CGContext(
+            data: nil,
+            width: 1,
+            height: 1,
+            bitsPerComponent: 8,
+            bytesPerRow: 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+        if let cg = context?.makeImage() {
+            _ = NSImage(cgImage: cg, size: NSSize(width: 1, height: 1))
+        }
+    }
+
     @Test("downsamples a large cover to a small cell size")
     func downsamplesSmallCell() async throws {
         let url = try TestImage.solidPNG(width: 1000, height: 1000)


### PR DESCRIPTION
Slice 1 of #450.

## Summary

Two paths carried the 0.5 s playback position tick into `BocanRootView.body`, and from there into every child that cannot prove itself unchanged, ending in `TrackTable.updateNSView` re-diffing all 14,483 rows twice a second behind the Immersive Mode window.

1. The root body read `nowPlaying.position` to pass into `LyricsPane`. The pane now takes the model and reads the position only inside the editor sheet's content, so the tick invalidates the sheet alone.
2. `LyricsViewModel.positionDidChange` assigned nil to the published line index on every tick for a song without synced lyrics. A `@Published` assignment emits even when unchanged, and the root (`@ObservedObject`) and the tracks view (`@EnvironmentObject`) both re-render on each emission. It now publishes only when the index actually moves.

## Measured

Animation Hitches, 45 s of playback with the Songs list behind the immersive window, Debug build without Thread Sanitizer.

| Run | Hitches | Over 100 ms | Time hitching | Longest |
|---|---|---|---|---|
| Before | 107 | 77 | 14.0 s | 275 ms |
| Fix 1 only | 97 | 77 | 12.1 s | 175 ms |
| Fix 1 and 2 | 71 | 5 | 1.5 s | 167 ms |

The five remaining long hitches land on synced lyric line changes, about every three seconds. Each still re-renders the root and the table; slice 2 of #450 (a rows version so the table skips a no-op update) makes that cheap.

## Tests

- `RootPositionTickConventionTests`: the root body never reads `nowPlaying.position`; `LyricsPane` takes the model and reads the position only inside the sheet; the playback driver still forwards each tick to the lyrics model.
- `LyricsPositionPublishTests`: a tick publishes nothing without a document, and once per line change with a synced one.
- `ArtworkLoaderTests`: a main-thread AppKit warm-up. Marking the suite `@MainActor` (the 2026-09-01 fix) was not enough because `ArtworkLoader` is an actor, so the `NSImage` was still built off main and deadlocked against `WindowFadeTests` in two full `make test-ui` runs today. The warm-up walks the same `NSImage(cgImage:)` path on main and does not touch `NSApplication`, which fails in the host-less Xcode bundle.

## Gates

make format, make lint, make test-ui (1060 tests), make test-coverage, make build all green.

Refs #450. The radio restore flake seen during this work is tracked separately in #451.