### PR TITLE
perf(ui): skip the songs table's per-row walks when its inputs are unchanged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes.
+Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes. The table also stopped re-checking every one of its rows whenever anything else in the window updated, such as a synced lyric line changing, so those moments no longer cause a stutter either.
 
 Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.
 

--- a/Modules/UI/Sources/UI/Browse/TrackTable.swift
+++ b/Modules/UI/Sources/UI/Browse/TrackTable.swift
@@ -77,6 +77,11 @@ public struct TrackTable: NSViewRepresentable {
     public typealias Coordinator = TrackTableCoordinator
 
     let rows: [TrackRow]
+    /// The view model's counter for `rows` (#450). `updateNSView` walks the
+    /// rows only when this moved since the last apply; a parent re-render with
+    /// unchanged rows then costs nothing per row. Defaulted so callers that
+    /// build a table by hand (tests) need not supply it.
+    var rowsVersion = 0
     @Binding var selection: Set<Track.ID>
     @Binding var sortOrder: [KeyPathComparator<TrackRow>]
     let nowPlayingTrackID: Track.ID?
@@ -199,47 +204,53 @@ public struct TrackTable: NSViewRepresentable {
         guard let tableView = coordinator.tableView,
               let dataSource = coordinator.dataSource else { return }
 
-        // 1 — Structural change: a different set of track IDs.
-        let newIDs = self.rows.compactMap(\.id)
-        let oldIDs = coordinator.lastAppliedIDs
+        // 1 — Decide what moved since the last apply (#450). The rows version
+        // gates every per-row walk, so a parent re-render with unchanged
+        // inputs does no per-row work at all.
+        let plan = TrackTableUpdatePlan.make(
+            rowsVersion: self.rowsVersion,
+            ids: { self.rows.compactMap(\.id) },
+            nowPlayingID: self.nowPlayingTrackID,
+            selection: self.selection,
+            applied: coordinator.applied
+        )
+        switch plan.rowsWork {
+        case .structural:
+            self.applyStructuralChange(ids: plan.ids ?? [], coordinator: coordinator, dataSource: dataSource)
 
-        if newIDs != oldIDs {
-            coordinator.updateRows(self.rows)
-            coordinator.lastAppliedIDs = newIDs
-
-            // NSDiffableDataSourceSnapshot requires unique item identifiers.
-            // Guard against duplicate track IDs (e.g. the same track added
-            // twice to a playlist) by deduplicating while preserving order.
-            var seen = Set<Int64>()
-            let uniqueIDs = newIDs.filter { seen.insert($0).inserted }
-
-            var snapshot = NSDiffableDataSourceSnapshot<Int, Int64>()
-            snapshot.appendSections([0])
-            snapshot.appendItems(uniqueIDs)
-            let animated = coordinator.hasAppliedInitialSnapshot && !self.rows.isEmpty
-            dataSource.apply(snapshot, animatingDifferences: animated)
-            coordinator.hasAppliedInitialSnapshot = true
-        } else {
+        case .reconfigure:
             // 2 — Same ID set: reconfigure rows whose displayed content changed
             // (love toggled, play count bumped, rating, in-place tag edits) and
             // the rows gaining or losing the now-playing highlight.  Without
             // this the NSTableView keeps rendering stale cells until a reload.
             self.reconfigureChangedRows(coordinator: coordinator, dataSource: dataSource)
-        }
-        coordinator.lastNowPlayingID = self.nowPlayingTrackID
 
-        // 3 — Selection changed externally (e.g. syncSelectionToNowPlaying).
-        let expectedIndexes = IndexSet(
-            coordinator.rows.enumerated()
-                .compactMap { idx, row -> Int? in
-                    guard let id = row.id, selection.contains(id) else { return nil }
-                    return idx
-                }
+        case .unchanged:
+            // Rows unchanged; only the highlight may have moved.
+            Self.reload(rows: plan.highlightReload, dataSource: dataSource)
+        }
+        coordinator.applied = plan.applied(
+            after: coordinator.applied,
+            rowsVersion: self.rowsVersion,
+            nowPlayingID: self.nowPlayingTrackID,
+            selection: self.selection
         )
-        if tableView.selectedRowIndexes != expectedIndexes {
-            coordinator.isSyncingSelection = true
-            tableView.selectRowIndexes(expectedIndexes, byExtendingSelection: false)
-            coordinator.isSyncingSelection = false
+
+        // 3 — Selection changed externally (e.g. syncSelectionToNowPlaying),
+        // or the rows did: recomputing the index set walks every row.
+        if plan.syncSelection {
+            let expectedIndexes = IndexSet(
+                coordinator.rows.enumerated()
+                    .compactMap { idx, row -> Int? in
+                        guard let id = row.id, selection.contains(id) else { return nil }
+                        return idx
+                    }
+            )
+            if tableView.selectedRowIndexes != expectedIndexes {
+                coordinator.isSyncingSelection = true
+                tableView.selectRowIndexes(expectedIndexes, byExtendingSelection: false)
+                coordinator.isSyncingSelection = false
+            }
         }
 
         // 4 — Sort indicator changed externally (e.g. "Clear Sort" button).
@@ -260,6 +271,29 @@ public struct TrackTable: NSViewRepresentable {
         self.applyScrollIfNeeded(coordinator: coordinator, tableView: tableView)
     }
 
+    /// A different set of track IDs: rebuild the rows dictionary and apply a
+    /// new snapshot.
+    private func applyStructuralChange(
+        ids: [Int64],
+        coordinator: TrackTableCoordinator,
+        dataSource: TrackDiffableDataSource
+    ) {
+        coordinator.updateRows(self.rows)
+
+        // NSDiffableDataSourceSnapshot requires unique item identifiers.
+        // Guard against duplicate track IDs (e.g. the same track added
+        // twice to a playlist) by deduplicating while preserving order.
+        var seen = Set<Int64>()
+        let uniqueIDs = ids.filter { seen.insert($0).inserted }
+
+        var snapshot = NSDiffableDataSourceSnapshot<Int, Int64>()
+        snapshot.appendSections([0])
+        snapshot.appendItems(uniqueIDs)
+        let animated = coordinator.hasAppliedInitialSnapshot && !self.rows.isEmpty
+        dataSource.apply(snapshot, animatingDifferences: animated)
+        coordinator.hasAppliedInitialSnapshot = true
+    }
+
     /// Reloads only the rows whose rendered content changed (or whose
     /// now-playing highlight is gained/lost) while the set of track IDs is
     /// unchanged.  `reloadItems` re-runs the cell provider for those identifiers
@@ -278,12 +312,18 @@ public struct TrackTable: NSViewRepresentable {
         }
         // The now-playing highlight depends on `nowPlayingTrackID`, not on row
         // content, so the outgoing and incoming now-playing rows must refresh
-        // too — even when their underlying values are identical.
-        if coordinator.lastNowPlayingID != self.nowPlayingTrackID {
-            if let old = coordinator.lastNowPlayingID, let oldID = old { changed.append(oldID) }
+        // too, even when their underlying values are identical.
+        if coordinator.applied.nowPlayingID != self.nowPlayingTrackID {
+            if let old = coordinator.applied.nowPlayingID, let oldID = old { changed.append(oldID) }
             if let new = self.nowPlayingTrackID, let newID = new { changed.append(newID) }
         }
         coordinator.updateRows(self.rows)
+        Self.reload(rows: changed, dataSource: dataSource)
+    }
+
+    /// Reloads the given rows in place, ignoring IDs the snapshot does not hold
+    /// and duplicates. A no-op for an empty list.
+    private static func reload(rows changed: [Int64], dataSource: TrackDiffableDataSource) {
         guard !changed.isEmpty else { return }
         var snapshot = dataSource.snapshot()
         let existing = Set(snapshot.itemIdentifiers(inSection: 0))

--- a/Modules/UI/Sources/UI/Browse/TrackTableCoordinator.swift
+++ b/Modules/UI/Sources/UI/Browse/TrackTableCoordinator.swift
@@ -14,9 +14,9 @@ public final class TrackTableCoordinator: NSObject, NSTableViewDelegate {
     var rows: [TrackRow] = []
     var rowsByID: [Int64: TrackRow] = [:]
 
-    // Change-detection state used in updateNSView.
-    var lastAppliedIDs: [Int64] = []
-    var lastNowPlayingID: Track.ID?
+    /// What the last `updateNSView` applied: rows version, IDs, highlight,
+    /// selection. `TrackTableUpdatePlan` diffs the next inputs against it (#450).
+    var applied = TrackTableUpdatePlan.Applied()
     var hasAppliedInitialSnapshot = false
     /// Tracks the last scroll-request counter processed to avoid re-scrolling.
     var lastScrollRequest: Int = -1

--- a/Modules/UI/Sources/UI/Browse/TrackTableUpdatePlan.swift
+++ b/Modules/UI/Sources/UI/Browse/TrackTableUpdatePlan.swift
@@ -1,0 +1,79 @@
+import Persistence
+
+// MARK: - TrackTableUpdatePlan
+
+/// The decision half of `TrackTable.updateNSView` (#450): which of the table's
+/// inputs changed since the last apply, and therefore which per-row work is
+/// owed. SwiftUI calls `updateNSView` whenever the parent re-renders, whether
+/// or not the table's inputs moved, and with 14,000 rows every unconditional
+/// walk (the content diff, the rows dictionary, the selection index set) was a
+/// visible hitch. The rows version gates all of them: an update whose inputs
+/// are unchanged does nothing per row. Pure, so it is unit-tested host-less.
+struct TrackTableUpdatePlan: Equatable {
+    /// What the coordinator remembers from the last apply.
+    struct Applied: Equatable {
+        /// `nil` until the first apply.
+        var rowsVersion: Int?
+        var ids: [Int64] = []
+        /// `Track.ID` is `Int64?`, so this is a double optional: outer `nil`
+        /// means "never applied", inner `nil` means "nothing playing".
+        var nowPlayingID: Track.ID?
+        var selection: Set<Track.ID>?
+    }
+
+    enum RowsWork: Equatable {
+        /// The rows version is unchanged: no walk, no dictionary rebuild.
+        case unchanged
+        /// Same ID set under a new version: diff content and reload changed rows.
+        case reconfigure
+        /// A different ID set: apply a new snapshot.
+        case structural
+    }
+
+    var rowsWork: RowsWork
+    /// The ID list computed for this update; only present when the rows changed.
+    var ids: [Int64]?
+    /// Rows to reload because the now-playing highlight moved while the rows
+    /// did not; `reconfigure` covers the highlight itself.
+    var highlightReload: [Int64]
+    /// The selection index set walk is owed only when the rows or the
+    /// selection changed since the last apply.
+    var syncSelection: Bool
+
+    /// - Parameter ids: the current row IDs, computed only when the rows
+    ///   version moved (a compactMap over every row).
+    static func make(
+        rowsVersion: Int,
+        ids: () -> [Int64],
+        nowPlayingID: Track.ID?,
+        selection: Set<Track.ID>,
+        applied: Applied
+    ) -> Self {
+        let rowsChanged = applied.rowsVersion != rowsVersion
+        var plan = Self(rowsWork: .unchanged, ids: nil, highlightReload: [], syncSelection: false)
+        if rowsChanged {
+            let newIDs = ids()
+            plan.ids = newIDs
+            plan.rowsWork = newIDs == applied.ids ? .reconfigure : .structural
+        } else if applied.nowPlayingID != nowPlayingID {
+            plan.highlightReload = [applied.nowPlayingID, nowPlayingID].compactMap { $0.flatMap(\.self) }
+        }
+        plan.syncSelection = rowsChanged || applied.selection != selection
+        return plan
+    }
+
+    /// The memory to keep once this plan has been applied.
+    func applied(
+        after previous: Applied,
+        rowsVersion: Int,
+        nowPlayingID: Track.ID?,
+        selection: Set<Track.ID>
+    ) -> Applied {
+        Applied(
+            rowsVersion: rowsVersion,
+            ids: self.ids ?? previous.ids,
+            nowPlayingID: nowPlayingID,
+            selection: selection
+        )
+    }
+}

--- a/Modules/UI/Sources/UI/Browse/TracksView+Tables.swift
+++ b/Modules/UI/Sources/UI/Browse/TracksView+Tables.swift
@@ -7,6 +7,7 @@ extension TracksView {
     var sortableTable: some View {
         TrackTable(
             rows: self.vm.rows,
+            rowsVersion: self.vm.rowsVersion,
             selection: self.$vm.selection,
             sortOrder: self.$sortOrder,
             nowPlayingTrackID: self.nowPlaying.nowPlayingTrackID,
@@ -22,6 +23,7 @@ extension TracksView {
     var plainTable: some View {
         TrackTable(
             rows: self.vm.rows,
+            rowsVersion: self.vm.rowsVersion,
             selection: self.$vm.selection,
             sortOrder: self.$sortOrder,
             nowPlayingTrackID: self.nowPlaying.nowPlayingTrackID,

--- a/Modules/UI/Sources/UI/ViewModels/TracksViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/TracksViewModel.swift
@@ -83,7 +83,13 @@ public final class TracksViewModel {
     // MARK: - State
 
     /// Decorated, already-sorted rows rendered by `Table`.
-    public private(set) var rows: [TrackRow] = []
+    public private(set) var rows: [TrackRow] = [] {
+        didSet { self.rowsVersion &+= 1 }
+    }
+
+    /// Moves on every write to `rows`, in-place ones included, via `didSet` so no
+    /// path can forget it; `TrackTable` skips its per-row walks while it holds (#450).
+    public private(set) var rowsVersion = 0
     /// `true` while a load or search is in flight.
     public private(set) var isLoading = false
     /// The currently selected track IDs.
@@ -118,9 +124,7 @@ public final class TracksViewModel {
 
     // MARK: - Computed back-compat accessors
 
-    /// The raw tracks, in their current display order.  Preserved for
-    /// call sites (playback, context menus, tests) that don't need the
-    /// decorated row values.
+    /// The raw tracks in display order, for call sites that don't need the decorated rows.
     public var tracks: [Track] {
         self.rows.map(\.track)
     }

--- a/Modules/UI/Tests/UITests/TrackTableUpdatePlanTests.swift
+++ b/Modules/UI/Tests/UITests/TrackTableUpdatePlanTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import Testing
+@testable import UI
+
+// MARK: - TrackTableUpdatePlanTests
+
+/// #450 slice 2: `TrackTable.updateNSView` runs on every parent re-render.
+/// The plan decides what per-row work is owed from the rows version, the ID
+/// list, the highlight and the selection; identical inputs must owe nothing.
+@Suite("TrackTableUpdatePlan")
+struct TrackTableUpdatePlanTests {
+    private typealias Plan = TrackTableUpdatePlan
+
+    /// A memory of one earlier apply of version 3 with rows 1...3, track 2
+    /// playing and row 1 selected.
+    private let applied = Plan.Applied(rowsVersion: 3, ids: [1, 2, 3], nowPlayingID: .some(2), selection: [1])
+
+    /// An ID closure that records whether the plan asked for the IDs.
+    private final class IDProbe {
+        var asked = false
+        let ids: [Int64]
+
+        init(_ ids: [Int64]) {
+            self.ids = ids
+        }
+
+        func callAsFunction() -> [Int64] {
+            self.asked = true
+            return self.ids
+        }
+    }
+
+    @Test("identical inputs owe no rows work, no reload, no selection walk, and never compute the IDs")
+    func identicalInputsAreANoop() {
+        let probe = IDProbe([1, 2, 3])
+        let plan = Plan.make(rowsVersion: 3, ids: probe.callAsFunction, nowPlayingID: .some(2), selection: [1], applied: self.applied)
+
+        #expect(plan.rowsWork == .unchanged)
+        #expect(plan.ids == nil)
+        #expect(plan.highlightReload.isEmpty)
+        #expect(!plan.syncSelection)
+        #expect(!probe.asked, "the ID walk must not run when the rows version is unchanged")
+    }
+
+    @Test("a new version with the same IDs reconfigures and walks the selection")
+    func sameIDsNewVersionReconfigures() {
+        let probe = IDProbe([1, 2, 3])
+        let plan = Plan.make(rowsVersion: 4, ids: probe.callAsFunction, nowPlayingID: .some(2), selection: [1], applied: self.applied)
+
+        #expect(plan.rowsWork == .reconfigure)
+        #expect(plan.ids == [1, 2, 3])
+        #expect(plan.highlightReload.isEmpty, "reconfigure covers the highlight rows itself")
+        #expect(plan.syncSelection)
+        #expect(probe.asked)
+    }
+
+    @Test("a new version with different IDs is structural")
+    func differentIDsAreStructural() {
+        let plan = Plan.make(rowsVersion: 4, ids: { [1, 2, 3, 4] }, nowPlayingID: .some(2), selection: [1], applied: self.applied)
+
+        #expect(plan.rowsWork == .structural)
+        #expect(plan.ids == [1, 2, 3, 4])
+        #expect(plan.syncSelection)
+    }
+
+    @Test("the first apply with empty rows reconfigures, so the initial snapshot is not the empty one")
+    func firstApplyWithEmptyRowsIsNotStructural() {
+        // Matches the pre-#450 behaviour: an empty first call applied no
+        // snapshot, so the later population did not animate as an update.
+        let plan = Plan.make(rowsVersion: 0, ids: { [] }, nowPlayingID: nil, selection: [], applied: Plan.Applied())
+        #expect(plan.rowsWork == .reconfigure)
+        #expect(plan.syncSelection)
+    }
+
+    @Test("the first apply with rows is structural")
+    func firstApplyWithRowsIsStructural() {
+        let plan = Plan.make(rowsVersion: 0, ids: { [7, 8] }, nowPlayingID: nil, selection: [], applied: Plan.Applied())
+        #expect(plan.rowsWork == .structural)
+        #expect(plan.ids == [7, 8])
+    }
+
+    @Test("a highlight move with unchanged rows reloads only the outgoing and incoming rows")
+    func highlightMoveReloadsTwoRows() {
+        let probe = IDProbe([1, 2, 3])
+        let plan = Plan.make(rowsVersion: 3, ids: probe.callAsFunction, nowPlayingID: .some(3), selection: [1], applied: self.applied)
+
+        #expect(plan.rowsWork == .unchanged)
+        #expect(plan.highlightReload == [2, 3])
+        #expect(!plan.syncSelection)
+        #expect(!probe.asked)
+    }
+
+    @Test("playback stopping reloads only the outgoing row")
+    func highlightClearedReloadsOutgoingRow() {
+        let plan = Plan.make(rowsVersion: 3, ids: { [1, 2, 3] }, nowPlayingID: .some(nil), selection: [1], applied: self.applied)
+        #expect(plan.highlightReload == [2])
+    }
+
+    @Test("a selection change alone walks the selection and nothing else")
+    func selectionChangeAloneSyncsSelection() {
+        let probe = IDProbe([1, 2, 3])
+        let plan = Plan.make(rowsVersion: 3, ids: probe.callAsFunction, nowPlayingID: .some(2), selection: [1, 3], applied: self.applied)
+
+        #expect(plan.rowsWork == .unchanged)
+        #expect(plan.highlightReload.isEmpty)
+        #expect(plan.syncSelection)
+        #expect(!probe.asked)
+    }
+
+    @Test("applied(after:) keeps the previous IDs when the plan did not compute them")
+    func appliedKeepsIDsAcrossNoopUpdates() {
+        let noop = Plan.make(rowsVersion: 3, ids: { [] }, nowPlayingID: .some(3), selection: [2], applied: self.applied)
+        let next = noop.applied(after: self.applied, rowsVersion: 3, nowPlayingID: .some(3), selection: [2])
+
+        #expect(next == Plan.Applied(rowsVersion: 3, ids: [1, 2, 3], nowPlayingID: .some(3), selection: [2]))
+
+        let structural = Plan.make(rowsVersion: 4, ids: { [9] }, nowPlayingID: .some(3), selection: [2], applied: next)
+        let after = structural.applied(after: next, rowsVersion: 4, nowPlayingID: .some(3), selection: [2])
+        #expect(after.ids == [9])
+        #expect(after.rowsVersion == 4)
+    }
+}

--- a/Modules/UI/Tests/UITests/TracksViewModelRowsVersionTests.swift
+++ b/Modules/UI/Tests/UITests/TracksViewModelRowsVersionTests.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Testing
+@testable import Persistence
+@testable import UI
+
+// MARK: - TracksViewModelRowsVersionTests
+
+/// #450 slice 2: `TracksViewModel.rowsVersion` is what lets `TrackTable` skip
+/// its per-row walks. It must move on every write to `rows`, including the
+/// in-place single-row rewrite, and stay put for everything else.
+@Suite("TracksViewModel rows version")
+@MainActor
+struct TracksViewModelRowsVersionTests {
+    private func makeVM() async throws -> TracksViewModel {
+        let db = try await Database(location: .inMemory)
+        return TracksViewModel(
+            repository: TrackRepository(database: db),
+            artistRepository: ArtistRepository(database: db),
+            albumRepository: AlbumRepository(database: db)
+        )
+    }
+
+    private func makeTrack(id: Int64, title: String, playCount: Int = 0) -> Track {
+        var track = Track(
+            fileURL: "file:///tmp/\(title).flac",
+            fileSize: 1024,
+            fileMtime: 0,
+            fileFormat: "flac",
+            duration: 180,
+            title: title,
+            addedAt: 0,
+            updatedAt: 0
+        )
+        track.id = id
+        track.playCount = playCount
+        return track
+    }
+
+    @Test("setTracks moves the version once")
+    func setTracksBumps() async throws {
+        let vm = try await makeVM()
+        let before = vm.rowsVersion
+
+        vm.setTracks([self.makeTrack(id: 1, title: "A"), self.makeTrack(id: 2, title: "B")])
+
+        #expect(vm.rows.count == 2)
+        #expect(vm.rowsVersion == before + 1)
+    }
+
+    @Test("an in-place single-row update moves the version, and a no-match update does not")
+    func updateRowsBumpsOnlyWhenARowChanges() async throws {
+        let vm = try await makeVM()
+        vm.setTracks([self.makeTrack(id: 1, title: "A"), self.makeTrack(id: 2, title: "B")])
+        let before = vm.rowsVersion
+
+        vm.updateRows(for: [self.makeTrack(id: 2, title: "B", playCount: 5)])
+        #expect(vm.rows.first { $0.id == 2 }?.track.playCount == 5)
+        #expect(vm.rowsVersion > before, "the table must learn about a play-count bump")
+
+        let afterMatch = vm.rowsVersion
+        vm.updateRows(for: [self.makeTrack(id: 99, title: "not here")])
+        #expect(vm.rowsVersion == afterMatch, "a track outside the list touches no row")
+    }
+
+    @Test("selection changes leave the version alone")
+    func selectionDoesNotBump() async throws {
+        let vm = try await makeVM()
+        vm.setTracks([self.makeTrack(id: 1, title: "A")])
+        let before = vm.rowsVersion
+
+        vm.selection = [1]
+        vm.selection = []
+
+        #expect(vm.rowsVersion == before)
+    }
+}


### PR DESCRIPTION
Slice 2 of #450.

## Summary

SwiftUI calls `TrackTable.updateNSView` on every parent re-render, whether or not the table's inputs moved, and each call walked all 14,483 rows three times: the content diff, the rows dictionary rebuild, and the selection index set. After slice 1 (#452) that walk still ran on every synced lyric line change, about 150 ms each.

- `TracksViewModel` gains `rowsVersion`, bumped from a `didSet` on `rows`, so every write path moves it, including the in-place single-row rewrite in `updateRows(for:)`.
- `TrackTable` carries the version, and a new pure helper, `TrackTableUpdatePlan`, decides what per-row work is owed: nothing when the version is unchanged (a highlight move reloads only the outgoing and incoming rows); the existing content diff when the version moved with the same IDs; the existing snapshot apply when the IDs differ. The selection index set is recomputed only when the rows or the selection changed.
- The coordinator's `lastAppliedIDs` and `lastNowPlayingID` fold into one `Applied` value.

## Measured

Animation Hitches, 45 s of playback with the Songs list behind the immersive window, Debug build without Thread Sanitizer.

| Run | Hitches | Over 100 ms | Time hitching |
|---|---|---|---|
| Before #450 | 107 | 77 | 14.0 s |
| After slice 1 (#452) | 71 | 5 | 1.5 s |
| After slice 2 | 51 | 1 | 0.8 s |

The one remaining long hitch has no main-thread CPU samples inside it: the thread was blocked, not walking rows. It is a one-off, not the line-change pattern.

## Tests

- `TrackTableUpdatePlanTests`: each branch host-less, including that identical inputs never evaluate the ID closure, and that `applied(after:)` keeps the IDs across no-op updates.
- `TracksViewModelRowsVersionTests`: the version moves on `setTracks`, on an in-place row update, not on a no-match update, and not on selection changes.

## Gates

make format, make lint, make test-ui (1072 tests), make test-coverage, make build all green.

## Follow-ups filed from the review of this slice

- #453 `updateRows(for:)` copies the rows array once per matched row now that `rows` has a `didSet`.
- #454 `rowsVersion` defaults to 0, so a call site that omits it would silently freeze the table.
- #455 `SubsonicSongTable` has the same per-update walk and could adopt the plan helper.
- #456 `TracksView` observes the whole lyrics model; precise observation would stop the re-render at the source rather than making it cheap.

Refs #450