### PR TITLE
fix(ui): subscribe to queue changes before the first reads so a seed cannot fall between them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+The now-playing display no longer misses a queue change that lands in the first instants after launch while nothing is playing, which could leave it on "Not playing" until the next track change.
+
 Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes. The table also stopped re-checking every one of its rows whenever anything else in the window updated, such as a synced lyric line changing, so those moments no longer cause a stutter either.
 
 Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.

--- a/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
@@ -846,14 +846,23 @@ private extension NowPlayingViewModel {
         // Observe queue changes to keep UI state (shuffle, repeat, stop-after-current) in sync.
         self.queueChangesTask = Task { [weak self] in
             guard let self else { return }
+            // Subscribe before any other read. The queue registers the
+            // subscriber synchronously, so nothing emitted after this line
+            // can be missed; the three reads below each hop to the queue
+            // actor, and a replace landing in that window used to go unseen
+            // by both this loop and the one-shot seed above (#451).
+            let changes = await qp.queue.changes()
             let initialRepeat = await qp.queue.repeatMode
             let initialShuffle = await qp.queue.shuffleState
             let initialStopAfter = await qp.queue.stopAfterCurrent
             self.repeatMode = initialRepeat
             self.shuffleOn = initialShuffle != .off
             self.stopAfterCurrent = initialStopAfter
+            // Whatever the queue held before the subscription is not on the
+            // stream: derive the display from it once, then follow the stream.
+            await self.syncDisplayWithQueueIfIdle(qp)
 
-            for await change in await qp.queue.changes() {
+            for await change in changes {
                 switch change {
                 case let .stopAfterCurrentChanged(enabled):
                     self.stopAfterCurrent = enabled

--- a/Modules/UI/Tests/UITests/ViewModelTests/NowPlayingRadioRestoreTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/NowPlayingRadioRestoreTests.swift
@@ -49,9 +49,14 @@ struct NowPlayingRadioRestoreTests {
         await player.waitUntilActivated()
         // View model first, queue second: the E2E seeder's ordering. The
         // queue-change observation (.reset) must sync the display because
-        // no engine emission ever follows a replace at rest.
+        // no engine emission ever follows a replace at rest. No sleep here
+        // on purpose (#451): the replace lands while the observer is still
+        // attaching, which is the race the view model must absorb. It
+        // subscribes before its first reads and derives the display once
+        // after, so the seed is caught whichever side of the subscription
+        // it falls on. The old 200 ms sleep only hid the race until a
+        // loaded run stretched the attach past it.
         let vm = NowPlayingViewModel(engine: player, database: db)
-        try await Task.sleep(nanoseconds: 200_000_000) // let observers attach
 
         let url = try #require(URL(string: "http://127.0.0.1:9/never"))
         let item = QueueItem.makeInternetRadio(name: "Late FM", streamURL: url, homePage: nil)


### PR DESCRIPTION
Closes #451.

## The bug

`NowPlayingViewModel`'s queue observer read repeat, shuffle and stop-after state (three actor hops) before it subscribed to `queue.changes()`. A replace or clear landing in that window was emitted to nobody: the one-shot seed had already read the current item, and the stream did not exist yet. At rest nothing else touches the engine, so the display stayed on "Not playing" until the next track change.

The test for this case slept 200 ms "to let the observer attach", which hid the race until a loaded parallel run stretched the attach past it. It then failed in three of four full `make test-ui` runs on 2026-09-07 and passed alone every time.

## The fix

The observer subscribes first. `PlaybackQueue.changes()` registers the subscriber synchronously, so nothing emitted after that line can be missed. It then reads the initial state and derives the display from the queue once before following the stream, so a seed is caught on either side of the subscription.

The test drops its sleep and replaces the queue immediately after creating the view model, which is the race itself.

## Gates

make format, make lint, make test-ui (1072 tests), make test-coverage (95%), make build all green.

## Environment notes, not from this change

Homebrew moved SwiftLint to 0.65.1 and relinked FFmpeg overnight. The first is handled on `chore/swiftlint-0-65-1` (policy: pins move forward, see #458). The second left stale build manifests in DerivedData that a scheme clean fixed.