### PR TITLE
test(ui): wait for the persisted destination itself, not for a rebuilt view model per poll

### DIFF
--- a/Modules/UI/Tests/UITests/ViewModelTests/LibraryDestinationPersistenceTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/LibraryDestinationPersistenceTests.swift
@@ -24,18 +24,30 @@ struct LibraryDestinationPersistenceTests {
         // (the fresh-VM default is `.songs`).
         vm.selectedDestination = .albums
 
-        // Poll a freshly-constructed VM's restore until it observes the navigated
-        // destination. The sink debounces 250 ms; 3 s is a generous ceiling.
-        var restored: SidebarDestination = .songs
-        let deadline = Date().addingTimeInterval(3.0)
+        // The sink debounces 250 ms and then writes "ui.state.v2". Wait for
+        // that write by reading the settings store, a cheap query, rather than
+        // by building a LibraryViewModel per poll: a full view model starts a
+        // dozen observation tasks, so on a loaded parallel run the old loop
+        // overshot its 3 s ceiling before the debounced save could land, and
+        // failed CI twice on 2026-09-08. The ceiling is generous on purpose;
+        // the test ends the moment the write appears.
+        let settings = SettingsRepository(database: db)
+        var saved: SidebarDestination?
+        let deadline = Date().addingTimeInterval(15.0)
         while Date() < deadline {
-            let probe = LibraryViewModel(database: db, engine: MockTransport())
-            await probe.restoreUIState()
-            restored = probe.selectedDestination
-            if restored == .albums { break }
+            if let state = try await settings.get(UIStateV2.self, for: "ui.state.v2") {
+                saved = state.selectedDestination
+                if saved == .albums {
+                    break
+                }
+            }
             try await Task.sleep(nanoseconds: 50_000_000)
         }
+        #expect(saved == .albums, "the debounced sink never persisted the navigation; last saved \(String(describing: saved))")
 
-        #expect(restored == .albums, "navigated destination should auto-persist; got \(restored)")
+        // One probe, built after the write landed, proves the restore path.
+        let probe = LibraryViewModel(database: db, engine: MockTransport())
+        await probe.restoreUIState()
+        #expect(probe.selectedDestination == .albums, "a fresh launch should restore the navigated destination")
     }
 }


### PR DESCRIPTION
Refs #464 (the sweep) and #458.

## The flake

`LibraryDestinationPersistenceTests` polled for the debounced save by constructing a whole `LibraryViewModel` and awaiting its restore on every 50 ms tick, under a 3 s ceiling. A full view model starts a dozen observation tasks, so on a loaded parallel runner the loop overshot the ceiling before the 250 ms debounce could write. It failed the #463 Build and Test job twice on 2026-09-08 and passed alone every time.

## The fix

The test now reads the settings store for `ui.state.v2` on each tick, a cheap query, with a 15 s ceiling it leaves the moment the write lands, and only then builds one probe view model to prove the restore path.

In the full `make test-ui` run the write took 4.7 s to land under load, which the old ceiling would have failed; the suite passed, 1072 tests.

Same defect class as #451. The remaining timing-dependent tests are catalogued in #464.