### PR TITLE
chore(release): 2.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.14.1](https://github.com/bocan/bocan-music/compare/v2.14.0...v2.14.1) (2026-09-08)
+
 The now-playing display no longer misses a queue change that lands in the first instants after launch while nothing is playing, which could leave it on "Not playing" until the next track change.
 
 Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes. The table also stopped re-checking every one of its rows whenever anything else in the window updated, such as a synced lyric line changing, so those moments no longer cause a stutter either.
@@ -14,6 +16,16 @@ Immersive Mode and the visualizer no longer stutter twice a second while a song 
 Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.
 
 This release pairs with Bòcan Music for Android 0.4.0, which carries the phone side of that fix: the phone now waits while the Mac converts the song again instead of giving up on it until the next sync. Install it from https://github.com/bocan/bocan-music-android/releases/tag/v0.4.0 so both ends match.
+
+### For developers
+
+**Fixed**
+- sync: re-encode a released transcode artifact on an urgent request ([#446](https://github.com/bocan/bocan-music/pull/446))
+- ui: keep the playback position tick out of the root body and the songs table ([#452](https://github.com/bocan/bocan-music/pull/452))
+- ui: subscribe to queue changes before the first reads so a seed cannot fall between them ([#462](https://github.com/bocan/bocan-music/pull/462))
+
+**Changed**
+- ui: skip the songs table's per-row walks when its inputs are unchanged ([#457](https://github.com/bocan/bocan-music/pull/457))
 
 ## [2.14.0](https://github.com/bocan/bocan-music/compare/v2.13.0...v2.14.0) (2026-09-05)
 

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -21,7 +21,7 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>2.14.0</string>
+    <string>2.14.1</string>
     <key>CFBundleVersion</key>
     <string>$(CURRENT_PROJECT_VERSION)</string>
     <key>LSApplicationCategoryType</key>


### PR DESCRIPTION
Cut by the Release workflow. Merging tags v2.14.1 and publishes it.

---

The now-playing display no longer misses a queue change that lands in the first instants after launch while nothing is playing, which could leave it on "Not playing" until the next track change.

Immersive Mode and the visualizer no longer stutter twice a second while a song plays with the full Songs list open. The main window was quietly redrawing every row of the songs table on each playback tick; it now leaves the table alone until something in it actually changes. The table also stopped re-checking every one of its rows whenever anything else in the window updated, such as a synced lyric line changing, so those moments no longer cause a stutter either.

Phone Sync no longer leaves a converted song stuck as pending forever. If the phone lost a song after the Mac had already sent it (for example when Android stopped the app mid-transfer to save battery), the Mac now converts that song again the next time the phone asks for it, instead of answering busy on every sync.

This release pairs with Bòcan Music for Android 0.4.0, which carries the phone side of that fix: the phone now waits while the Mac converts the song again instead of giving up on it until the next sync. Install it from https://github.com/bocan/bocan-music-android/releases/tag/v0.4.0 so both ends match.

Full changelog: https://github.com/bocan/bocan-music/compare/v2.14.0...v2.14.1