### PR TITLE
chore(scripts): add make vital-signs with a recorded history and trend view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,9 @@ Pods/
 # XcodeGen (keep project.yml, ignore generated project)
 # (we commit Bocan.xcodeproj - it's generated but part of the repo)
 
+# Python (Scripts/*.py helpers)
+__pycache__/
+
 # Editor
 .idea/
 *.swp

--- a/.periphery.yml
+++ b/.periphery.yml
@@ -1,0 +1,22 @@
+# Periphery (dead-code scanner) configuration. Read by `periphery scan`;
+# Scripts/vital-signs.sh runs it under `make vital-signs SLOW=1`.
+#
+# The app scheme builds every local package under Modules/ as a dependency,
+# so one scheme indexes all twelve modules plus App/ and the Xcode test
+# bundle. References from the Xcode bundle's tests count as uses; the SPM
+# module test targets are not part of this scheme, so a declaration used
+# only by those tests will be reported. Treat such reports as "used only by
+# tests", which is still worth knowing.
+project: Bocan.xcodeproj
+schemes:
+  - Bocan
+
+# public is how the modules expose API to App and to each other, and both
+# sides are indexed, so unused public declarations are real findings and
+# redundant public modifiers get reported too. Flip to true to silence both.
+retain_public: false
+
+# AppKit drives menu actions, table delegates and KVO through @objc
+# selectors that the index store cannot always tie back to a reference.
+# Keep those, at the cost of missing some genuinely dead @objc methods.
+retain_objc_accessible: true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bootstrap bundle-fpcalc embed-deps brew-bundle doctor open generate build tests test test-coverage coverage-all test-e2e test-e2e-smoke test-audio-engine test-persistence test-metadata test-library test-acoustics test-ui test-playback test-scrobble test-subsonic test-podcasts test-sync-server test-observability uitest lint format pseudolocale format-check install-hooks clean downloads audit-db data-dictionary vital-signs
+.PHONY: help bootstrap bundle-fpcalc embed-deps brew-bundle doctor open generate build tests test test-coverage coverage-all test-e2e test-e2e-smoke test-audio-engine test-persistence test-metadata test-library test-acoustics test-ui test-playback test-scrobble test-subsonic test-podcasts test-sync-server test-observability uitest lint format pseudolocale format-check install-hooks clean downloads audit-db data-dictionary vital-signs vital-signs-trend
 
 # Pinned SwiftLint version. CI installs this exact release; `doctor` fails when
 # the local install differs. SwiftLint's force_unwrapping/superfluous_disable
@@ -357,6 +357,11 @@ clean:
 downloads:
 	@Scripts/release-downloads.sh
 
-## vital-signs: Print the repository vital signs as a markdown table, each row with the command that produced it (SLOW=1 adds the clean Release build time)
+## vital-signs: Print the repository vital signs as a markdown table, each row with the command that produced it
+## SLOW=1 adds the clean Release build time and the Periphery scan; RECORD=1 appends the run to docs/vital-signs.csv; LABEL=pre-2.15.0 names it
 vital-signs:
-	@Scripts/vital-signs.sh $(if $(SLOW),--slow,)
+	@Scripts/vital-signs.sh $(if $(SLOW),--slow,) $(if $(RECORD),--record,) $(if $(LABEL),--label $(LABEL),)
+
+## vital-signs-trend: Show docs/vital-signs.csv as one column per recorded run, with the change and a sparkline (N=6 runs to show, FILTER=text)
+vital-signs-trend:
+	@Scripts/vital-signs-trend.py $(or $(N),6) $(if $(FILTER),--filter "$(FILTER)",)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help bootstrap bundle-fpcalc embed-deps brew-bundle doctor open generate build tests test test-coverage coverage-all test-e2e test-e2e-smoke test-audio-engine test-persistence test-metadata test-library test-acoustics test-ui test-playback test-scrobble test-subsonic test-podcasts test-sync-server test-observability uitest lint format pseudolocale format-check install-hooks clean downloads audit-db data-dictionary
+.PHONY: help bootstrap bundle-fpcalc embed-deps brew-bundle doctor open generate build tests test test-coverage coverage-all test-e2e test-e2e-smoke test-audio-engine test-persistence test-metadata test-library test-acoustics test-ui test-playback test-scrobble test-subsonic test-podcasts test-sync-server test-observability uitest lint format pseudolocale format-check install-hooks clean downloads audit-db data-dictionary vital-signs
 
 # Pinned SwiftLint version. CI installs this exact release; `doctor` fails when
 # the local install differs. SwiftLint's force_unwrapping/superfluous_disable
@@ -356,3 +356,7 @@ clean:
 ## downloads: Print GitHub Release DMG download counts (server-side, no client telemetry)
 downloads:
 	@Scripts/release-downloads.sh
+
+## vital-signs: Print the repository vital signs as a markdown table, each row with the command that produced it (SLOW=1 adds the clean Release build time)
+vital-signs:
+	@Scripts/vital-signs.sh $(if $(SLOW),--slow,)

--- a/Scripts/vital-signs-trend.py
+++ b/Scripts/vital-signs-trend.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""vital-signs-trend.py: show docs/vital-signs.csv as one column per run.
+
+Usage: Scripts/vital-signs-trend.py [N] [--csv PATH] [--filter TEXT]
+
+  N              number of most recent runs to show as columns (default 6)
+  --csv PATH     history file (default docs/vital-signs.csv)
+  --filter TEXT  only metrics whose name contains TEXT (case-insensitive)
+
+The history is the long-format CSV that `Scripts/vital-signs.sh --record`
+appends to: date, commit, label, metric, value, unit, note. This script
+pivots it: one row per metric, one column per run (headed by the run's label,
+or its date when unlabelled), the change against the previous recorded value,
+and a sparkline over every recorded run, not only the ones shown. An empty
+cell is a run where the metric was unmeasured or absent.
+"""
+
+import csv
+import sys
+from collections import OrderedDict
+
+BARS = "▁▂▃▄▅▆▇█"
+GAP = "·"
+
+
+def to_float(text):
+    text = (text or "").strip()
+    if not text:
+        return None
+    try:
+        return float(text)
+    except ValueError:
+        return None
+
+
+def fmt_delta(last, prev):
+    diff = last - prev
+    if diff == 0:
+        return "0"
+    if float(last).is_integer() and float(prev).is_integer():
+        return f"{int(diff):+d}"
+    return f"{diff:+.2f}".rstrip("0").rstrip(".")
+
+
+def sparkline(values):
+    numbers = [v for v in values if v is not None]
+    if not numbers:
+        return ""
+    low, high = min(numbers), max(numbers)
+    out = []
+    for v in values:
+        if v is None:
+            out.append(GAP)
+        elif high == low:
+            out.append(BARS[4])
+        else:
+            idx = int(round((v - low) / (high - low) * (len(BARS) - 1)))
+            out.append(BARS[idx])
+    return "".join(out)
+
+
+def parse_args(argv):
+    count, path, needle = 6, "docs/vital-signs.csv", ""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("-h", "--help"):
+            print(__doc__.strip())
+            sys.exit(0)
+        if arg == "--csv":
+            i += 1
+            path = argv[i]
+        elif arg == "--filter":
+            i += 1
+            needle = argv[i].lower()
+        elif arg.isdigit():
+            count = int(arg)
+        else:
+            sys.exit(f"unknown argument: {arg}")
+        i += 1
+    return count, path, needle
+
+
+def main():
+    count, path, needle = parse_args(sys.argv[1:])
+    try:
+        with open(path, newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+    except FileNotFoundError:
+        sys.exit(f"no history at {path}; run Scripts/vital-signs.sh --record first")
+    if not rows:
+        sys.exit(f"{path} has a header and no rows")
+
+    runs = OrderedDict()   # (date, commit, label) -> {metric: value text}
+    units = OrderedDict()  # metric -> unit, in first-seen order
+    for row in rows:
+        key = (row["date"], row["commit"], row["label"])
+        runs.setdefault(key, {})[row["metric"]] = row["value"].strip()
+        units.setdefault(row["metric"], "")
+        if row["unit"]:
+            units[row["metric"]] = row["unit"]
+
+    keys = sorted(runs, key=lambda k: k[0])
+    shown = keys[-count:]
+
+    def head(key):
+        return key[2] or key[0][:10]
+
+    print("| Metric | " + " | ".join(head(k) for k in shown) + " | Δ | Trend |")
+    print("|---|" + "---:|" * len(shown) + "---:|---|")
+
+    for metric, unit in units.items():
+        if needle and needle not in metric.lower():
+            continue
+        series = [to_float(runs[k].get(metric)) for k in keys]
+        cells = [runs[k].get(metric, "") for k in shown]
+        last = series[-1]
+        earlier = [v for v in series[:-1] if v is not None]
+        if last is None:
+            delta = ""
+        elif not earlier:
+            delta = "new"
+        else:
+            delta = fmt_delta(last, earlier[-1])
+        name = f"{metric} ({unit})" if unit else metric
+        print(f"| {name} | " + " | ".join(cells) + f" | {delta} | {sparkline(series)} |")
+
+
+if __name__ == "__main__":
+    main()

--- a/Scripts/vital-signs.allowlist
+++ b/Scripts/vital-signs.allowlist
@@ -1,0 +1,9 @@
+# Allowlist for Scripts/vital-signs.sh.
+#
+# One ripgrep glob per line. Files matching a glob are excluded from the
+# "outside the allowlist" counts of `Task {` and `Timer.scheduledTimer`.
+# Add a file here only with a reason in a trailing comment. An empty list
+# means the "outside" count equals the "all" count.
+#
+# Example:
+# Modules/Playback/Sources/Playback/SleepTimer.swift  # the one timer the app owns

--- a/Scripts/vital-signs.sh
+++ b/Scripts/vital-signs.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# vital-signs.sh: print the repository's vital signs as a markdown table.
+# Every row shows the metric, its value, and the exact command that produced
+# the value, so each number can be re-run and audited by hand.
+#
+# Usage: Scripts/vital-signs.sh [--slow]
+#   --slow   also time a clean Release build (several minutes) and, when a
+#            .periphery.yml exists, run a Periphery dead-code scan.
+#
+# Source-based counts are scoped to Modules/*/Sources and App/, with tests
+# counted separately. Coverage and test timing are read from the artefacts
+# the last `make test-coverage` and `make coverage-all` left behind; nothing
+# is rebuilt. A metric that cannot be measured prints "unmeasured" and why.
+# Nothing is estimated.
+#
+# shellcheck disable=SC2016  # commands are quoted strings shown to the reader
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+SLOW=0
+for arg in "$@"; do
+    case "$arg" in
+        --slow) SLOW=1 ;;
+        -h | --help)
+            sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        *)
+            echo "unknown argument: $arg" >&2
+            exit 2
+            ;;
+    esac
+done
+
+for tool in rg jq xcrun git; do
+    command -v "$tool" >/dev/null || {
+        echo "missing tool: $tool" >&2
+        exit 2
+    }
+done
+
+# Scope strings reused in the printed commands. SRC is expanded by the shell
+# when the command runs; the reader can paste the command as printed.
+SRC='Modules/*/Sources App'
+SUM="awk -F: '{s+=\$NF} END{print s+0}'"
+COUNT="wc -l | tr -d ' '"
+XCRESULT='build/TestResults.xcresult'
+ALLOWLIST='Scripts/vital-signs.allowlist'
+ERR_FILE="$(mktemp)"
+trap 'rm -f "$ERR_FILE"' EXIT
+
+# --- table helpers -----------------------------------------------------------
+
+escape_cell() {
+    printf '%s' "$1" | sed 's/|/\\|/g'
+}
+
+row() { # metric, value, command
+    printf '| %s | %s | `%s` |\n' \
+        "$(escape_cell "$1")" "$(escape_cell "$2")" "$(escape_cell "$3")"
+}
+
+section() {
+    printf '| **%s** | | |\n' "$1"
+}
+
+# Run a command string, print its output as the value. rg exits 1 on no match,
+# so pipefail is off inside the evaluation; a real error shows up on stderr and
+# is reported instead of a silent zero.
+measure() { # metric, command
+    local metric="$1" cmd="$2" value
+    value="$(set +o pipefail; eval "$cmd" 2>"$ERR_FILE")" || true
+    if [[ -z "$value" && -s "$ERR_FILE" ]]; then
+        value="error: $(head -n 1 "$ERR_FILE")"
+    elif [[ -z "$value" ]]; then
+        value="no output"
+    fi
+    row "$metric" "$value" "$cmd"
+}
+
+unmeasured() { # metric, reason, command that would produce it
+    row "$1" "unmeasured: $2" "$3"
+}
+
+mtime() {
+    stat -f '%Sm' -t '%Y-%m-%d %H:%M' "$1"
+}
+
+# --- header ------------------------------------------------------------------
+
+echo "# Bòcan vital signs"
+echo
+echo "Generated $(date '+%Y-%m-%d %H:%M %Z') at commit $(git rev-parse --short HEAD) on branch $(git branch --show-current)."
+echo "Source counts cover Modules/*/Sources and App/ unless a row says tests. Rows read from artefacts carry the artefact's date. Unmeasured rows say why."
+echo
+echo "| Metric | Value | Command |"
+echo "|---|---|---|"
+
+# --- size --------------------------------------------------------------------
+
+section "Size"
+for dir in Modules/*/; do
+    module="$(basename "$dir")"
+    measure "Swift lines · $module (sources)" \
+        "rg --files Modules/$module/Sources -g '*.swift' | xargs cat | $COUNT"
+done
+measure "Swift lines · App (sources)" "rg --files App -g '*.swift' | xargs cat | $COUNT"
+measure "Swift lines · all sources" "rg --files $SRC -g '*.swift' | xargs cat | $COUNT"
+measure "Swift lines · all tests" "rg --files Modules/*/Tests -g '*.swift' | xargs cat | $COUNT"
+
+# --- tests -------------------------------------------------------------------
+
+section "Tests"
+TEST_RE='^\s*(@Test\b|func test[A-Z])'
+for dir in Modules/*/; do
+    module="$(basename "$dir")"
+    measure "Tests · $module (@Test and XCTest funcs)" \
+        "rg -c '$TEST_RE' Modules/$module/Tests -g '*.swift' | $SUM"
+done
+measure "Tests · all modules" "rg -c '$TEST_RE' Modules/*/Tests -g '*.swift' | $SUM"
+
+if [[ -d "$XCRESULT" ]]; then
+    XCR_DATE="$(mtime "$XCRESULT")"
+    measure "Tests · Xcode bundle run ($XCR_DATE)" \
+        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '.totalTestCount'"
+    measure "Test suite wall time · Xcode bundle ($XCR_DATE)" \
+        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '(((.finishTime - .startTime) * 10 | round) / 10 | tostring) + \" s\"'"
+else
+    unmeasured "Tests · Xcode bundle run" "no $XCRESULT; run make test-coverage first" "make test-coverage"
+    unmeasured "Test suite wall time · Xcode bundle" "no $XCRESULT; run make test-coverage first" "make test-coverage"
+fi
+unmeasured "Test suite wall time · SPM modules" \
+    "swift test leaves no timing artefact; time the run itself" "time make coverage-all"
+
+# --- coverage ----------------------------------------------------------------
+
+section "Coverage"
+if [[ -d "$XCRESULT" ]]; then
+    measure "Coverage · Xcode bundle gate, BocanTests.xctest ($XCR_DATE)" \
+        "xcrun xccov view --report --json $XCRESULT | jq -r '.targets[] | select(.name == \"BocanTests.xctest\") | (((.lineCoverage * 1000 | round) / 10) | tostring) + \"%\"'"
+else
+    unmeasured "Coverage · Xcode bundle gate" "no $XCRESULT; run make test-coverage first" "make test-coverage"
+fi
+for dir in Modules/*/; do
+    module="$(basename "$dir")"
+    profdata="Modules/$module/.build/debug/codecov/default.profdata"
+    binary="Modules/$module/.build/debug/${module}PackageTests.xctest/Contents/MacOS/${module}PackageTests"
+    if [[ -f "$profdata" && -x "$binary" ]]; then
+        # The same llvm-cov invocation Scripts/coverage-all.sh uses, on the
+        # artefacts it left behind, so the number matches make coverage-all.
+        measure "Coverage · $module (coverage-all artefact $(mtime "$profdata"))" \
+            "xcrun llvm-cov report $binary -instr-profile=$profdata -ignore-filename-regex='(\.build|/Tests/|/checkouts/|\.derivedSources)' Modules/$module/Sources/ | awk '/^TOTAL/ {print \$10}'"
+    else
+        have_prof="no"; [[ -f "$profdata" ]] && have_prof="yes"
+        have_bin="no"; [[ -x "$binary" ]] && have_bin="yes"
+        unmeasured "Coverage · $module" \
+            "no coverage-all artefacts (profdata: $have_prof, test binary: $have_bin); run make coverage-all" \
+            "make coverage-all"
+    fi
+done
+
+# --- code quality ------------------------------------------------------------
+
+section "Code quality"
+unmeasured "Duplication percentage" \
+    "no duplication scanner is installed or wired; the maintainability audit (docs/design-spec/maintainability-audit/findings-ledger.md) was a manual ledger" \
+    "none"
+
+PERIPHERY_CMD="periphery scan --quiet --format json | jq length"
+if ! command -v periphery >/dev/null; then
+    unmeasured "Dead code · Periphery results" "periphery is not installed" "$PERIPHERY_CMD"
+elif [[ ! -f .periphery.yml ]]; then
+    unmeasured "Dead code · Periphery results" \
+        "periphery $(periphery version 2>/dev/null || echo '?') is installed but not configured (no .periphery.yml); run periphery scan --setup once" \
+        "periphery scan --setup"
+elif (( SLOW )); then
+    measure "Dead code · Periphery results" "$PERIPHERY_CMD"
+else
+    unmeasured "Dead code · Periphery results" "pass --slow (Periphery builds the project, several minutes)" "$PERIPHERY_CMD"
+fi
+
+# try? split. The house rule (CLAUDE.md) wants an `else { log.warning }`
+# companion. "With companion" is read strictly as a try? whose `else {` has an
+# AppLogger call on the same line or the next one; everything else counts as
+# without. Both commands are printed so the heuristic can be inspected.
+TRY_TOTAL_CMD="rg -o 'try\?' $SRC -g '*.swift' | $COUNT"
+TRY_WITH_CMD="rg -U -o 'try\?[^\n]*\belse\s*\{[^\n]*(\n[^\n]*)?\blog\.(warning|error|info|debug|notice|fault)\(' $SRC -g '*.swift' | rg -c 'try\?'"
+try_total="$(set +o pipefail; eval "$TRY_TOTAL_CMD" 2>/dev/null || true)"
+try_with="$(set +o pipefail; eval "$TRY_WITH_CMD" 2>/dev/null || true)"
+try_with="${try_with:-0}"
+row "try? in sources (occurrences)" "$try_total" "$TRY_TOTAL_CMD"
+row "try? with an else { log } companion (log call on the else line or the next)" "$try_with" "$TRY_WITH_CMD"
+row "try? without a companion" "$((try_total - try_with))" "(try? occurrences) - (try? with companion)"
+
+measure "nonisolated(unsafe) in sources" "rg -o 'nonisolated\(unsafe\)' $SRC -g '*.swift' | $COUNT"
+measure "@unchecked Sendable in sources" "rg -o '@unchecked Sendable' $SRC -g '*.swift' | $COUNT"
+measure "@MainActor outside the UI layer (Modules/* except UI; App is UI layer)" \
+    "rg -o '@MainActor' Modules/*/Sources -g '*.swift' -g '!Modules/UI/**' | $COUNT"
+
+for word in TODO FIXME XCTSkip fatalError; do
+    measure "$word in sources (whole word)" "rg -ow '$word' $SRC -g '*.swift' | $COUNT"
+done
+measure "XCTSkip in tests (whole word)" "rg -ow 'XCTSkip' Modules/*/Tests -g '*.swift' | $COUNT"
+
+# Allowlist: one ripgrep glob per line, excluded from the "outside" counts.
+ALLOW_GLOBS=""
+if [[ -f "$ALLOWLIST" ]]; then
+    while IFS= read -r line || [[ -n "$line" ]]; do
+        line="${line%%#*}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        [[ -z "$line" ]] && continue
+        ALLOW_GLOBS+=" -g '!$line'"
+    done <"$ALLOWLIST"
+fi
+measure "Task { in sources (all)" "rg -oF 'Task {' $SRC -g '*.swift' | $COUNT"
+measure "Task { outside the allowlist ($ALLOWLIST)" "rg -oF 'Task {' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT"
+measure "Timer.scheduledTimer in sources (all)" "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift' | $COUNT"
+measure "Timer.scheduledTimer outside the allowlist ($ALLOWLIST)" \
+    "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT"
+
+measure "sql: statements (lines)" "rg -c 'sql:' $SRC -g '*.swift' | $SUM"
+measure "sql: lines containing \\( interpolation" "rg -n 'sql:' $SRC -g '*.swift' | rg -cF '\\('"
+
+measure "ADRs" "ls docs/design-spec/ADR-*.md | $COUNT"
+measure "ADRs with a status field" \
+    "rg -il '^(\*\*)?status(\*\*)?\s*:' docs/design-spec/ADR-*.md | $COUNT"
+
+# --- build and runtime -------------------------------------------------------
+
+section "Build and runtime"
+RELEASE_CMD="xcodebuild -project Bocan.xcodeproj -scheme Bocan -configuration Release -destination 'generic/platform=macOS' -derivedDataPath build/vital-signs-derived ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS= clean build"
+if (( SLOW )); then
+    mkdir -p build
+    start="$(date +%s)"
+    if eval "$RELEASE_CMD" >build/vital-signs-release-build.log 2>&1; then
+        row "Clean build time · Release (unsigned, arm64)" "$(( $(date +%s) - start )) s" "time $RELEASE_CMD"
+    else
+        row "Clean build time · Release (unsigned, arm64)" "build failed; see build/vital-signs-release-build.log" "time $RELEASE_CMD"
+    fi
+else
+    unmeasured "Clean build time · Release (unsigned, arm64)" "pass --slow (several minutes)" "time $RELEASE_CMD"
+fi
+
+TRACE_CMD="xctrace record --template 'Time Profiler' --all-processes --time-limit 30s --output build/launch.trace & sleep 2 && open -a Bocan; then read the signpost interval from the trace (xctrace export --xpath)"
+unmeasured "Cold start to first window (app.bootstrap signpost)" \
+    "the signpost exists (App/BocanApp.swift) but info-level log lines are not persisted to the unified log and no launch trace is automated" \
+    "$TRACE_CMD"
+unmeasured "Library load time for the large fixture (tracks.load, library.scan signposts)" \
+    "no large fixture exists yet; the signposts exist" \
+    "$TRACE_CMD"
+unmeasured "Hitch ratio for the standard playback scenario" \
+    "no standard playback scenario or performance gate exists yet" \
+    "xctrace record --template 'Animation Hitches' --attach <pid> --time-limit 45s --output build/hitches.trace"
+unmeasured "Idle memory after 10 minutes of playback" \
+    "the 10-minute playback protocol is not automated; sample a running instance by hand" \
+    "ps -o rss= -p \$(pgrep -x Bocan) | awk '{printf \"%.0f MB\\n\", \$1 / 1024}'"

--- a/Scripts/vital-signs.sh
+++ b/Scripts/vital-signs.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
 # vital-signs.sh: print the repository's vital signs as a markdown table.
-# Every row shows the metric, its value, and the exact command that produced
-# the value, so each number can be re-run and audited by hand.
+# Every row shows the metric, its value, a note, and the exact command that
+# produced the value, so each number can be re-run and audited by hand.
 #
-# Usage: Scripts/vital-signs.sh [--slow]
-#   --slow   also time a clean Release build (several minutes) and, when a
-#            .periphery.yml exists, run a Periphery dead-code scan.
+# Usage: Scripts/vital-signs.sh [--slow] [--record] [--label NAME]
+#   --slow        also time a clean Release build (several minutes) and, when
+#                 a .periphery.yml exists, run a Periphery dead-code scan.
+#   --record      append this run to docs/vital-signs.csv, one row per metric
+#                 (date, commit, label, metric, value, unit, note), so runs
+#                 can be compared. Scripts/vital-signs-trend.py reads it.
+#   --label NAME  name this run in the history (for example pre-2.15.0).
 #
 # Source-based counts are scoped to Modules/*/Sources and App/, with tests
 # counted separately. Coverage and test timing are read from the artefacts
 # the last `make test-coverage` and `make coverage-all` left behind; nothing
 # is rebuilt. A metric that cannot be measured prints "unmeasured" and why.
 # Nothing is estimated.
+#
+# Metric names are the keys of the history, so they stay stable; anything
+# that varies per run (artefact dates, reasons) goes in the note column.
+# If a command changes in a way that changes the meaning of its number,
+# rename the metric so the old series ends there.
 #
 # shellcheck disable=SC2016  # commands are quoted strings shown to the reader
 set -euo pipefail
@@ -20,18 +29,26 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 SLOW=0
-for arg in "$@"; do
-    case "$arg" in
+RECORD=0
+LABEL=""
+while [[ $# -gt 0 ]]; do
+    case "$1" in
         --slow) SLOW=1 ;;
+        --record) RECORD=1 ;;
+        --label)
+            LABEL="${2:?--label needs a name}"
+            shift
+            ;;
         -h | --help)
-            sed -n '2,14p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,23p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         *)
-            echo "unknown argument: $arg" >&2
+            echo "unknown argument: $1" >&2
             exit 2
             ;;
     esac
+    shift
 done
 
 for tool in rg jq xcrun git; do
@@ -48,8 +65,13 @@ SUM="awk -F: '{s+=\$NF} END{print s+0}'"
 COUNT="wc -l | tr -d ' '"
 XCRESULT='build/TestResults.xcresult'
 ALLOWLIST='Scripts/vital-signs.allowlist'
+CSV='docs/vital-signs.csv'
 ERR_FILE="$(mktemp)"
 trap 'rm -f "$ERR_FILE"' EXIT
+
+RUN_DATE="$(date '+%Y-%m-%dT%H:%M')"
+RUN_COMMIT="$(git rev-parse --short HEAD)"
+RECORDED=0
 
 # --- table helpers -----------------------------------------------------------
 
@@ -57,31 +79,67 @@ escape_cell() {
     printf '%s' "$1" | sed 's/|/\\|/g'
 }
 
-row() { # metric, value, command
-    printf '| %s | %s | `%s` |\n' \
-        "$(escape_cell "$1")" "$(escape_cell "$2")" "$(escape_cell "$3")"
+csv_field() { # quote when the field holds a comma, a quote or a newline
+    local f="$1"
+    if [[ "$f" == *[,\"$'\n']* ]]; then
+        f="${f//\"/\"\"}"
+        printf '"%s"' "$f"
+    else
+        printf '%s' "$f"
+    fi
+}
+
+record() { # metric, value, note. Splits "74.5 s" into value 74.5 unit s.
+    local metric="$1" value="$2" note="$3" num="" unit=""
+    local num_re='^([0-9]+(\.[0-9]+)?)[[:space:]]*(%|s|MB)?$'
+    if [[ "$value" =~ $num_re ]]; then
+        num="${BASH_REMATCH[1]}"
+        unit="${BASH_REMATCH[3]}"
+    else
+        # unmeasured, error, no output: an empty value keeps the series honest
+        note="${note:-$value}"
+    fi
+    if [[ ! -f "$CSV" ]]; then
+        mkdir -p "$(dirname "$CSV")"
+        echo "date,commit,label,metric,value,unit,note" >"$CSV"
+    fi
+    printf '%s,%s,%s,%s,%s,%s,%s\n' \
+        "$RUN_DATE" "$RUN_COMMIT" "$(csv_field "$LABEL")" "$(csv_field "$metric")" \
+        "$num" "$unit" "$(csv_field "$note")" >>"$CSV"
+    RECORDED=$((RECORDED + 1))
+}
+
+row() { # metric, value, command, [note]
+    local metric="$1" value="$2" cmd="$3" note="${4:-}"
+    printf '| %s | %s | %s | `%s` |\n' \
+        "$(escape_cell "$metric")" "$(escape_cell "$value")" \
+        "$(escape_cell "$note")" "$(escape_cell "$cmd")"
+    if (( RECORD )); then
+        record "$metric" "$value" "$note"
+    fi
 }
 
 section() {
-    printf '| **%s** | | |\n' "$1"
+    printf '| **%s** | | | |\n' "$1"
 }
 
 # Run a command string, print its output as the value. rg exits 1 on no match,
 # so pipefail is off inside the evaluation; a real error shows up on stderr and
 # is reported instead of a silent zero.
-measure() { # metric, command
-    local metric="$1" cmd="$2" value
+measure() { # metric, command, [note]
+    local metric="$1" cmd="$2" note="${3:-}" value
     value="$(set +o pipefail; eval "$cmd" 2>"$ERR_FILE")" || true
     if [[ -z "$value" && -s "$ERR_FILE" ]]; then
-        value="error: $(head -n 1 "$ERR_FILE")"
+        value="error"
+        note="$(head -n 1 "$ERR_FILE")"
     elif [[ -z "$value" ]]; then
         value="no output"
     fi
-    row "$metric" "$value" "$cmd"
+    row "$metric" "$value" "$cmd" "$note"
 }
 
 unmeasured() { # metric, reason, command that would produce it
-    row "$1" "unmeasured: $2" "$3"
+    row "$1" "unmeasured" "$3" "$2"
 }
 
 mtime() {
@@ -92,11 +150,11 @@ mtime() {
 
 echo "# Bòcan vital signs"
 echo
-echo "Generated $(date '+%Y-%m-%d %H:%M %Z') at commit $(git rev-parse --short HEAD) on branch $(git branch --show-current)."
-echo "Source counts cover Modules/*/Sources and App/ unless a row says tests. Rows read from artefacts carry the artefact's date. Unmeasured rows say why."
+echo "Generated $RUN_DATE at commit $RUN_COMMIT on branch $(git branch --show-current)${LABEL:+, labelled $LABEL}."
+echo "Source counts cover Modules/*/Sources and App/ unless a row says tests. Rows read from artefacts carry the artefact's date in the note. Unmeasured rows say why."
 echo
-echo "| Metric | Value | Command |"
-echo "|---|---|---|"
+echo "| Metric | Value | Note | Command |"
+echo "|---|---|---|---|"
 
 # --- size --------------------------------------------------------------------
 
@@ -116,17 +174,20 @@ section "Tests"
 TEST_RE='^\s*(@Test\b|func test[A-Z])'
 for dir in Modules/*/; do
     module="$(basename "$dir")"
-    measure "Tests · $module (@Test and XCTest funcs)" \
-        "rg -c '$TEST_RE' Modules/$module/Tests -g '*.swift' | $SUM"
+    measure "Tests · $module" \
+        "rg -c '$TEST_RE' Modules/$module/Tests -g '*.swift' | $SUM" \
+        "@Test attributes and XCTest funcs"
 done
 measure "Tests · all modules" "rg -c '$TEST_RE' Modules/*/Tests -g '*.swift' | $SUM"
 
 if [[ -d "$XCRESULT" ]]; then
-    XCR_DATE="$(mtime "$XCRESULT")"
-    measure "Tests · Xcode bundle run ($XCR_DATE)" \
-        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '.totalTestCount'"
-    measure "Test suite wall time · Xcode bundle ($XCR_DATE)" \
-        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '(((.finishTime - .startTime) * 10 | round) / 10 | tostring) + \" s\"'"
+    XCR_NOTE="artefact $(mtime "$XCRESULT")"
+    measure "Tests · Xcode bundle run" \
+        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '.totalTestCount'" \
+        "$XCR_NOTE"
+    measure "Test suite wall time · Xcode bundle" \
+        "xcrun xcresulttool get test-results summary --path $XCRESULT | jq -r '(((.finishTime - .startTime) * 10 | round) / 10 | tostring) + \" s\"'" \
+        "$XCR_NOTE"
 else
     unmeasured "Tests · Xcode bundle run" "no $XCRESULT; run make test-coverage first" "make test-coverage"
     unmeasured "Test suite wall time · Xcode bundle" "no $XCRESULT; run make test-coverage first" "make test-coverage"
@@ -138,10 +199,11 @@ unmeasured "Test suite wall time · SPM modules" \
 
 section "Coverage"
 if [[ -d "$XCRESULT" ]]; then
-    measure "Coverage · Xcode bundle gate, BocanTests.xctest ($XCR_DATE)" \
-        "xcrun xccov view --report --json $XCRESULT | jq -r '.targets[] | select(.name == \"BocanTests.xctest\") | (((.lineCoverage * 1000 | round) / 10) | tostring) + \"%\"'"
+    measure "Coverage · Xcode bundle gate (BocanTests.xctest)" \
+        "xcrun xccov view --report --json $XCRESULT | jq -r '.targets[] | select(.name == \"BocanTests.xctest\") | (((.lineCoverage * 1000 | round) / 10) | tostring) + \"%\"'" \
+        "$XCR_NOTE"
 else
-    unmeasured "Coverage · Xcode bundle gate" "no $XCRESULT; run make test-coverage first" "make test-coverage"
+    unmeasured "Coverage · Xcode bundle gate (BocanTests.xctest)" "no $XCRESULT; run make test-coverage first" "make test-coverage"
 fi
 for dir in Modules/*/; do
     module="$(basename "$dir")"
@@ -150,8 +212,9 @@ for dir in Modules/*/; do
     if [[ -f "$profdata" && -x "$binary" ]]; then
         # The same llvm-cov invocation Scripts/coverage-all.sh uses, on the
         # artefacts it left behind, so the number matches make coverage-all.
-        measure "Coverage · $module (coverage-all artefact $(mtime "$profdata"))" \
-            "xcrun llvm-cov report $binary -instr-profile=$profdata -ignore-filename-regex='(\.build|/Tests/|/checkouts/|\.derivedSources)' Modules/$module/Sources/ | awk '/^TOTAL/ {print \$10}'"
+        measure "Coverage · $module" \
+            "xcrun llvm-cov report $binary -instr-profile=$profdata -ignore-filename-regex='(\.build|/Tests/|/checkouts/|\.derivedSources)' Modules/$module/Sources/ | awk '/^TOTAL/ {print \$10}'" \
+            "coverage-all artefact $(mtime "$profdata")"
     else
         have_prof="no"; [[ -f "$profdata" ]] && have_prof="yes"
         have_bin="no"; [[ -x "$binary" ]] && have_bin="yes"
@@ -184,7 +247,7 @@ elif [[ ! -f .periphery.yml ]]; then
         "$PERIPHERY_SCAN_CMD"
 elif (( SLOW )); then
     mkdir -p build
-    measure "Dead code · Periphery scan (all findings, tests included)" "$PERIPHERY_SCAN_CMD"
+    measure "Dead code · Periphery scan" "$PERIPHERY_SCAN_CMD" "all findings, tests included"
     measure "Dead code · unused declarations in sources" \
         "jq '[.[] | select(.hints[] == \"unused\") | $PERIPHERY_SRC] | length' $PERIPHERY_RESULTS"
     measure "Dead code · assign-only properties in sources" \
@@ -206,22 +269,24 @@ TRY_WITH_CMD="rg -U -o 'try\?[^\n]*\belse\s*\{[^\n]*(\n[^\n]*)?\blog\.(warning|e
 try_total="$(set +o pipefail; eval "$TRY_TOTAL_CMD" 2>/dev/null || true)"
 try_with="$(set +o pipefail; eval "$TRY_WITH_CMD" 2>/dev/null || true)"
 try_with="${try_with:-0}"
-row "try? in sources (occurrences)" "$try_total" "$TRY_TOTAL_CMD"
-row "try? with an else { log } companion (log call on the else line or the next)" "$try_with" "$TRY_WITH_CMD"
-row "try? without a companion" "$((try_total - try_with))" "(try? occurrences) - (try? with companion)"
+row "try? in sources" "$try_total" "$TRY_TOTAL_CMD" "occurrences"
+row "try? with an else { log } companion" "$try_with" "$TRY_WITH_CMD" "log call on the else line or the next"
+row "try? without a companion" "$((try_total - try_with))" "(try? in sources) - (try? with companion)"
 
 measure "nonisolated(unsafe) in sources" "rg -o 'nonisolated\(unsafe\)' $SRC -g '*.swift' | $COUNT"
 measure "@unchecked Sendable in sources" "rg -o '@unchecked Sendable' $SRC -g '*.swift' | $COUNT"
-measure "@MainActor outside the UI layer (Modules/* except UI; App is UI layer)" \
-    "rg -o '@MainActor' Modules/*/Sources -g '*.swift' -g '!Modules/UI/**' | $COUNT"
+measure "@MainActor outside the UI layer" \
+    "rg -o '@MainActor' Modules/*/Sources -g '*.swift' -g '!Modules/UI/**' | $COUNT" \
+    "Modules/* except UI; App is UI layer"
 
 for word in TODO FIXME XCTSkip fatalError; do
-    measure "$word in sources (whole word)" "rg -ow '$word' $SRC -g '*.swift' | $COUNT"
+    measure "$word in sources" "rg -ow '$word' $SRC -g '*.swift' | $COUNT" "whole word"
 done
-measure "XCTSkip in tests (whole word)" "rg -ow 'XCTSkip' Modules/*/Tests -g '*.swift' | $COUNT"
+measure "XCTSkip in tests" "rg -ow 'XCTSkip' Modules/*/Tests -g '*.swift' | $COUNT" "whole word"
 
 # Allowlist: one ripgrep glob per line, excluded from the "outside" counts.
 ALLOW_GLOBS=""
+ALLOW_COUNT=0
 if [[ -f "$ALLOWLIST" ]]; then
     while IFS= read -r line || [[ -n "$line" ]]; do
         line="${line%%#*}"
@@ -229,16 +294,18 @@ if [[ -f "$ALLOWLIST" ]]; then
         line="${line%"${line##*[![:space:]]}"}"
         [[ -z "$line" ]] && continue
         ALLOW_GLOBS+=" -g '!$line'"
+        ALLOW_COUNT=$((ALLOW_COUNT + 1))
     done <"$ALLOWLIST"
 fi
-measure "Task { in sources (all)" "rg -oF 'Task {' $SRC -g '*.swift' | $COUNT"
-measure "Task { outside the allowlist ($ALLOWLIST)" "rg -oF 'Task {' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT"
-measure "Timer.scheduledTimer in sources (all)" "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift' | $COUNT"
-measure "Timer.scheduledTimer outside the allowlist ($ALLOWLIST)" \
-    "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT"
+ALLOW_NOTE="$ALLOWLIST, $ALLOW_COUNT entries"
+measure "Task { in sources" "rg -oF 'Task {' $SRC -g '*.swift' | $COUNT"
+measure "Task { outside the allowlist" "rg -oF 'Task {' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT" "$ALLOW_NOTE"
+measure "Timer.scheduledTimer in sources" "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift' | $COUNT"
+measure "Timer.scheduledTimer outside the allowlist" \
+    "rg -o 'Timer\.scheduledTimer' $SRC -g '*.swift'$ALLOW_GLOBS | $COUNT" "$ALLOW_NOTE"
 
-measure "sql: statements (lines)" "rg -c 'sql:' $SRC -g '*.swift' | $SUM"
-measure "sql: lines containing \\( interpolation" "rg -n 'sql:' $SRC -g '*.swift' | rg -cF '\\('"
+measure "sql: statements" "rg -c 'sql:' $SRC -g '*.swift' | $SUM" "lines"
+measure "sql: lines with interpolation" "rg -n 'sql:' $SRC -g '*.swift' | rg -cF '\\('" "contain \\("
 
 measure "ADRs" "ls docs/design-spec/ADR-*.md | $COUNT"
 measure "ADRs with a status field" \
@@ -252,20 +319,20 @@ if (( SLOW )); then
     mkdir -p build
     start="$(date +%s)"
     if eval "$RELEASE_CMD" >build/vital-signs-release-build.log 2>&1; then
-        row "Clean build time · Release (unsigned, arm64)" "$(( $(date +%s) - start )) s" "time $RELEASE_CMD"
+        row "Clean build time · Release" "$(( $(date +%s) - start )) s" "time $RELEASE_CMD" "unsigned, arm64"
     else
-        row "Clean build time · Release (unsigned, arm64)" "build failed; see build/vital-signs-release-build.log" "time $RELEASE_CMD"
+        row "Clean build time · Release" "error" "time $RELEASE_CMD" "build failed; see build/vital-signs-release-build.log"
     fi
 else
-    unmeasured "Clean build time · Release (unsigned, arm64)" "pass --slow (several minutes)" "time $RELEASE_CMD"
+    unmeasured "Clean build time · Release" "pass --slow (several minutes)" "time $RELEASE_CMD"
 fi
 
 TRACE_CMD="xctrace record --template 'Time Profiler' --all-processes --time-limit 30s --output build/launch.trace & sleep 2 && open -a Bocan; then read the signpost interval from the trace (xctrace export --xpath)"
-unmeasured "Cold start to first window (app.bootstrap signpost)" \
-    "the signpost exists (App/BocanApp.swift) but info-level log lines are not persisted to the unified log and no launch trace is automated" \
+unmeasured "Cold start to first window" \
+    "the app.bootstrap signpost exists (App/BocanApp.swift) but info-level log lines are not persisted to the unified log and no launch trace is automated" \
     "$TRACE_CMD"
-unmeasured "Library load time for the large fixture (tracks.load, library.scan signposts)" \
-    "no large fixture exists yet; the signposts exist" \
+unmeasured "Library load time for the large fixture" \
+    "no large fixture exists yet; the tracks.load and library.scan signposts exist" \
     "$TRACE_CMD"
 unmeasured "Hitch ratio for the standard playback scenario" \
     "no standard playback scenario or performance gate exists yet" \
@@ -273,3 +340,7 @@ unmeasured "Hitch ratio for the standard playback scenario" \
 unmeasured "Idle memory after 10 minutes of playback" \
     "the 10-minute playback protocol is not automated; sample a running instance by hand" \
     "ps -o rss= -p \$(pgrep -x Bocan) | awk '{printf \"%.0f MB\\n\", \$1 / 1024}'"
+
+if (( RECORD )); then
+    echo "recorded $RECORDED rows to $CSV as run $RUN_DATE ($RUN_COMMIT${LABEL:+, $LABEL})" >&2
+fi

--- a/Scripts/vital-signs.sh
+++ b/Scripts/vital-signs.sh
@@ -168,17 +168,33 @@ unmeasured "Duplication percentage" \
     "no duplication scanner is installed or wired; the maintainability audit (docs/design-spec/maintainability-audit/findings-ledger.md) was a manual ledger" \
     "none"
 
-PERIPHERY_CMD="periphery scan --quiet --format json | jq length"
+# Periphery reports three kinds of finding. Only "unused" is dead code;
+# assign-only properties and redundant public modifiers are reported on
+# their own rows. One scan writes build/periphery-results.json and the rows
+# read that file, so each number is a jq filter over the same scan. Findings
+# in test targets are excluded from the source rows by location.
+PERIPHERY_RESULTS='build/periphery-results.json'
+PERIPHERY_SCAN_CMD="periphery scan --quiet --format json > $PERIPHERY_RESULTS && jq length $PERIPHERY_RESULTS"
+PERIPHERY_SRC='select(.location | test("/Tests/|/UITests/") | not)'
 if ! command -v periphery >/dev/null; then
-    unmeasured "Dead code · Periphery results" "periphery is not installed" "$PERIPHERY_CMD"
+    unmeasured "Dead code · Periphery scan" "periphery is not installed" "$PERIPHERY_SCAN_CMD"
 elif [[ ! -f .periphery.yml ]]; then
-    unmeasured "Dead code · Periphery results" \
-        "periphery $(periphery version 2>/dev/null || echo '?') is installed but not configured (no .periphery.yml); run periphery scan --setup once" \
-        "periphery scan --setup"
+    unmeasured "Dead code · Periphery scan" \
+        "periphery $(periphery version 2>/dev/null || echo '?') is installed but not configured (no .periphery.yml)" \
+        "$PERIPHERY_SCAN_CMD"
 elif (( SLOW )); then
-    measure "Dead code · Periphery results" "$PERIPHERY_CMD"
+    mkdir -p build
+    measure "Dead code · Periphery scan (all findings, tests included)" "$PERIPHERY_SCAN_CMD"
+    measure "Dead code · unused declarations in sources" \
+        "jq '[.[] | select(.hints[] == \"unused\") | $PERIPHERY_SRC] | length' $PERIPHERY_RESULTS"
+    measure "Dead code · assign-only properties in sources" \
+        "jq '[.[] | select(.hints[] == \"assignOnlyProperty\") | $PERIPHERY_SRC] | length' $PERIPHERY_RESULTS"
+    measure "Dead code · redundant public modifiers in sources" \
+        "jq '[.[] | select(.hints[] == \"redundantPublicAccessibility\") | $PERIPHERY_SRC] | length' $PERIPHERY_RESULTS"
 else
-    unmeasured "Dead code · Periphery results" "pass --slow (Periphery builds the project, several minutes)" "$PERIPHERY_CMD"
+    unmeasured "Dead code · Periphery scan" \
+        "pass --slow (the first scan builds the project, several minutes; later scans reuse the index)" \
+        "$PERIPHERY_SCAN_CMD"
 fi
 
 # try? split. The house rule (CLAUDE.md) wants an `else { log.warning }`

--- a/docs/vital-signs.csv
+++ b/docs/vital-signs.csv
@@ -1,0 +1,74 @@
+date,commit,label,metric,value,unit,note
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Acoustics (sources),1241,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · AudioEngine (sources),7691,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Library (sources),11638,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Metadata (sources),1016,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Observability (sources),610,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Persistence (sources),11664,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Playback (sources),4426,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Podcasts (sources),4236,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Scrobble (sources),2750,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · Subsonic (sources),1876,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · SyncServer (sources),4126,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · UI (sources),57213,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · App (sources),4223,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · all sources,112710,,
+2026-09-10T12:55,dfb2ef2a,baseline,Swift lines · all tests,58166,,
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Acoustics,40,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · AudioEngine,207,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Library,390,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Metadata,85,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Observability,84,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Persistence,330,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Playback,195,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Podcasts,149,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Scrobble,95,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Subsonic,106,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · SyncServer,127,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · UI,1073,,@Test attributes and XCTest funcs
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · all modules,2881,,
+2026-09-10T12:55,dfb2ef2a,baseline,Tests · Xcode bundle run,833,,artefact 2026-09-09 01:21
+2026-09-10T12:55,dfb2ef2a,baseline,Test suite wall time · Xcode bundle,74.5,s,artefact 2026-09-09 01:21
+2026-09-10T12:55,dfb2ef2a,baseline,Test suite wall time · SPM modules,,,swift test leaves no timing artefact; time the run itself
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Xcode bundle gate (BocanTests.xctest),96,%,artefact 2026-09-09 01:21
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Acoustics,78.40,%,coverage-all artefact 2026-09-08 09:12
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · AudioEngine,,,"no coverage-all artefacts (profdata: no, test binary: yes); run make coverage-all"
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Library,78.63,%,coverage-all artefact 2026-09-08 09:12
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Metadata,91.76,%,coverage-all artefact 2026-09-08 09:12
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Observability,92.96,%,coverage-all artefact 2026-09-08 09:14
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Persistence,84.16,%,coverage-all artefact 2026-09-08 09:12
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Playback,67.49,%,coverage-all artefact 2026-09-08 09:13
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Podcasts,78.48,%,coverage-all artefact 2026-09-08 09:14
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Scrobble,74.04,%,coverage-all artefact 2026-09-08 09:13
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · Subsonic,78.55,%,coverage-all artefact 2026-09-08 09:14
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · SyncServer,91.46,%,coverage-all artefact 2026-09-08 09:14
+2026-09-10T12:55,dfb2ef2a,baseline,Coverage · UI,24.47,%,coverage-all artefact 2026-09-08 15:36
+2026-09-10T12:55,dfb2ef2a,baseline,Duplication percentage,,,no duplication scanner is installed or wired; the maintainability audit (docs/design-spec/maintainability-audit/findings-ledger.md) was a manual ledger
+2026-09-10T12:55,dfb2ef2a,baseline,Dead code · Periphery scan,1609,,"all findings, tests included"
+2026-09-10T12:55,dfb2ef2a,baseline,Dead code · unused declarations in sources,307,,
+2026-09-10T12:55,dfb2ef2a,baseline,Dead code · assign-only properties in sources,302,,
+2026-09-10T12:55,dfb2ef2a,baseline,Dead code · redundant public modifiers in sources,978,,
+2026-09-10T12:55,dfb2ef2a,baseline,try? in sources,334,,occurrences
+2026-09-10T12:55,dfb2ef2a,baseline,try? with an else { log } companion,1,,log call on the else line or the next
+2026-09-10T12:55,dfb2ef2a,baseline,try? without a companion,333,,
+2026-09-10T12:55,dfb2ef2a,baseline,nonisolated(unsafe) in sources,46,,
+2026-09-10T12:55,dfb2ef2a,baseline,@unchecked Sendable in sources,30,,
+2026-09-10T12:55,dfb2ef2a,baseline,@MainActor outside the UI layer,17,,Modules/* except UI; App is UI layer
+2026-09-10T12:55,dfb2ef2a,baseline,TODO in sources,4,,whole word
+2026-09-10T12:55,dfb2ef2a,baseline,FIXME in sources,0,,whole word
+2026-09-10T12:55,dfb2ef2a,baseline,XCTSkip in sources,0,,whole word
+2026-09-10T12:55,dfb2ef2a,baseline,fatalError in sources,13,,whole word
+2026-09-10T12:55,dfb2ef2a,baseline,XCTSkip in tests,0,,whole word
+2026-09-10T12:55,dfb2ef2a,baseline,Task { in sources,566,,
+2026-09-10T12:55,dfb2ef2a,baseline,Task { outside the allowlist,566,,"Scripts/vital-signs.allowlist, 0 entries"
+2026-09-10T12:55,dfb2ef2a,baseline,Timer.scheduledTimer in sources,1,,
+2026-09-10T12:55,dfb2ef2a,baseline,Timer.scheduledTimer outside the allowlist,1,,"Scripts/vital-signs.allowlist, 0 entries"
+2026-09-10T12:55,dfb2ef2a,baseline,sql: statements,378,,lines
+2026-09-10T12:55,dfb2ef2a,baseline,sql: lines with interpolation,9,,contain \(
+2026-09-10T12:55,dfb2ef2a,baseline,ADRs,90,,
+2026-09-10T12:55,dfb2ef2a,baseline,ADRs with a status field,0,,
+2026-09-10T12:55,dfb2ef2a,baseline,Clean build time · Release,93,s,"unsigned, arm64"
+2026-09-10T12:55,dfb2ef2a,baseline,Cold start to first window,,,the app.bootstrap signpost exists (App/BocanApp.swift) but info-level log lines are not persisted to the unified log and no launch trace is automated
+2026-09-10T12:55,dfb2ef2a,baseline,Library load time for the large fixture,,,no large fixture exists yet; the tracks.load and library.scan signposts exist
+2026-09-10T12:55,dfb2ef2a,baseline,Hitch ratio for the standard playback scenario,,,no standard playback scenario or performance gate exists yet
+2026-09-10T12:55,dfb2ef2a,baseline,Idle memory after 10 minutes of playback,,,the 10-minute playback protocol is not automated; sample a running instance by hand


### PR DESCRIPTION
Plan asset 1 from the AI-development programme: the repository's vital signs, measured, not estimated, and recorded so runs can be compared.

## Changes

- **`make vital-signs`** runs `Scripts/vital-signs.sh` and prints one markdown table: metric, value, note, and the exact command that produced the value, so any row can be pasted back into a shell and audited. Source counts use ripgrep over `Modules/*/Sources` and `App/`, with tests counted separately. Coverage and test timing are read from the artefacts the last `make test-coverage` and `make coverage-all` left behind, by re-running the same `llvm-cov` and `xccov` commands those scripts use; nothing is rebuilt. Metrics that cannot be measured print "unmeasured" and the reason. About three seconds.
- **`SLOW=1`** adds a timed clean, unsigned, arm64 Release build in its own derived-data folder under `build/`, and a Periphery dead-code scan. Periphery 3.8.0 is configured in `.periphery.yml` (Bocan scheme, which builds all twelve local packages; `retain_objc_accessible` on for the AppKit selector paths; `retain_public` off). One scan writes `build/periphery-results.json` and four rows read it: the total, then unused declarations, assign-only properties and redundant public modifiers in sources only.
- **`RECORD=1 LABEL=name`** appends one long-format row per metric to `docs/vital-signs.csv` (date, commit, label, metric, value, unit, note). Values are numeric with the unit beside them, so a spreadsheet pivots or charts the file without cleaning; an unmeasured metric keeps an empty value and its reason. Git history is the audit trail. Metric names are stable keys; per-run detail lives in the note.
- **`make vital-signs-trend`** (`N=` runs, `FILTER=` text) runs `Scripts/vital-signs-trend.py`, which pivots the history into one row per metric and one column per run, headed by its label, with the change against the previous recorded value and a sparkline over every run. The wide table is generated from the long file and never hand-edited.
- `Scripts/vital-signs.allowlist`: one ripgrep glob per line, excluded from the "outside the allowlist" counts of `Task {` and `Timer.scheduledTimer`. Empty for now.
- `.gitignore`: `__pycache__/`.

## Baseline, recorded 2026-09-10 as `baseline`

| Metric | Value |
|---|---|
| Swift source lines / test lines | 112,710 / 58,166 |
| Module tests / Xcode bundle tests | 2,881 / 833 |
| Xcode bundle wall time / gate coverage | 74.5 s / 96% |
| try? total / with `else { log }` companion / without | 334 / 1 / 333 |
| nonisolated(unsafe) / @unchecked Sendable / @MainActor outside UI | 46 / 30 / 17 |
| TODO / FIXME / XCTSkip / fatalError | 4 / 0 / 0 / 13 |
| Task { / Timer.scheduledTimer | 566 / 1 |
| sql: lines / with interpolation | 378 / 9 |
| ADRs / with a status field | 90 / 0 |
| Periphery: unused / assign-only / redundant public (sources) | 307 / 302 / 978 |
| Clean Release build | 93 s |

## Unmeasured, with the reason printed

Duplication (no scanner wired), SPM suite wall time (no artefact), cold start and large-fixture load (the signposts exist; no automated trace and no large fixture yet), hitch ratio (no standard playback scenario yet), idle memory after ten minutes of playback (protocol not automated). Each of these is a missing plan asset, not script work.

## Notes

- Do not run two Periphery scans at once: they share one derived-data folder and the second waits on its lock. A cold scan builds the project; a cached one takes seconds.
- The Periphery unused count includes API used only by the SPM module tests, which are outside the Bocan scheme. Triage separates dead code from test-only API.
- Rule for definitions, written in the script header: change a command in a way that changes the meaning of its number, and rename the metric so the old series ends there.

Not user-visible: `skip-changelog`.
