### PR TITLE
fix(library): say which file failed and why when a tag or cover-art save fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+When saving tags or cover art fails, the message now says which file failed and why, such as the file being read-only, instead of an error code.
+
 ## [2.14.1](https://github.com/bocan/bocan-music/compare/v2.14.0...v2.14.1) (2026-09-08)
 
 The now-playing display no longer misses a queue change that lands in the first instants after launch while nothing is playing, which could leave it on "Not playing" until the next track change.

--- a/Modules/Library/Sources/Library/Edit/EditError.swift
+++ b/Modules/Library/Sources/Library/Edit/EditError.swift
@@ -1,7 +1,10 @@
 import Foundation
 
 /// Errors thrown by the metadata-editing subsystem.
-public enum EditError: Error, Sendable, CustomStringConvertible {
+/// Conforms to `LocalizedError` so `localizedDescription`, which the UI shows
+/// in its error dialog, carries the reason instead of Foundation's fallback
+/// "(Library.EditError error 3.)" (#469).
+public enum EditError: Error, Sendable, CustomStringConvertible, LocalizedError {
     /// The track was not found in the database.
     case trackNotFound(Int64)
 
@@ -28,7 +31,17 @@ public enum EditError: Error, Sendable, CustomStringConvertible {
         case .cancelled:
             "Edit: cancelled"
         case let .partial(errors):
-            "Edit: \(errors.count) file(s) failed"
+            // Lead with one concrete reason: a batch that fails usually fails
+            // every file the same way, and the count alone tells the user nothing.
+            if let first = errors.sorted(by: { $0.key < $1.key }).first?.value {
+                "Edit: \(errors.count) file(s) failed. First: \(first)"
+            } else {
+                "Edit: \(errors.count) file(s) failed"
+            }
         }
+    }
+
+    public var errorDescription: String? {
+        self.description
     }
 }

--- a/Modules/Library/Tests/LibraryTests/MetadataEditServiceTests.swift
+++ b/Modules/Library/Tests/LibraryTests/MetadataEditServiceTests.swift
@@ -161,6 +161,35 @@ struct MetadataEditServiceTests {
         #expect(album.coverArtPath != nil)
     }
 
+    /// #469: a user saw "The operation couldn't be completed. (Library.EditError
+    /// error 3.)" when adding cover art. Code 3 is `.partial`, and the per-file
+    /// reason inside it was itself an opaque "MetadataError error N", so the
+    /// dialog could never say what went wrong. Both enums now carry their
+    /// reason through `localizedDescription`.
+    @Test func failedArtworkSaveReportsTheFileAndReasonNotAnErrorCode() async throws {
+        let db = try await makeDatabase()
+        let tmp = try tempMP3()
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        try FileManager.default.setAttributes([.posixPermissions: 0o444], ofItemAtPath: tmp.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o644], ofItemAtPath: tmp.path) }
+
+        let trackID = try await insertTrack(in: db, fileURL: tmp.absoluteString)
+        let svc = try MetadataEditService(database: db)
+        var patch = TrackTagPatch()
+        patch.coverArt = .some(Data([0xFF, 0xD8, 0xFF, 0xE0]) + Data(repeating: 0x42, count: 64))
+
+        do {
+            try await svc.edit(trackID: trackID, patch: patch)
+            Issue.record("editing a read-only file must fail")
+        } catch {
+            let message = error.localizedDescription
+            #expect(message.contains("1 file(s) failed"), "the wrapper names the count: \(message)")
+            #expect(message.contains("read-only"), "the wrapper carries the per-file reason: \(message)")
+            #expect(message.contains(tmp.lastPathComponent), "the wrapper names the file: \(message)")
+            #expect(!message.contains("error 3"), "no Foundation error code: \(message)")
+        }
+    }
+
     @Test func partialAlbumEditNeverClobbersExistingAlbumArt() async throws {
         let db = try await makeDatabase()
         let tmpA = try tempMP3()

--- a/Modules/Metadata/Sources/Metadata/Errors.swift
+++ b/Modules/Metadata/Sources/Metadata/Errors.swift
@@ -1,7 +1,12 @@
 import Foundation
 
 /// Errors thrown by the Metadata module.
-public enum MetadataError: Error, Sendable, CustomStringConvertible {
+///
+/// Conforms to `LocalizedError` so `localizedDescription` carries the reason.
+/// Without it, Foundation reports "(Metadata.MetadataError error 3.)", which
+/// is what callers that store `error.localizedDescription` end up showing to
+/// the user (#469).
+public enum MetadataError: Error, Sendable, CustomStringConvertible, LocalizedError {
     /// TagLib could not open or parse the file.
     case unreadableFile(URL, String)
 
@@ -30,5 +35,9 @@ public enum MetadataError: Error, Sendable, CustomStringConvertible {
         case let .readOnlyFile(url):
             "Metadata: file is read-only: \(url.lastPathComponent)"
         }
+    }
+
+    public var errorDescription: String? {
+        self.description
     }
 }

--- a/Modules/Metadata/Tests/MetadataTests/TagWriterTests.swift
+++ b/Modules/Metadata/Tests/MetadataTests/TagWriterTests.swift
@@ -306,6 +306,16 @@ struct TagWriterTests {
         #expect(throws: MetadataError.self) {
             try TagWriter().write(tags, to: tmp)
         }
+
+        // #469: the reason must survive `localizedDescription`, which is what
+        // callers store and show; Foundation's fallback is an opaque code.
+        do {
+            try TagWriter().write(tags, to: tmp)
+        } catch {
+            #expect(error.localizedDescription.contains("read-only"))
+            #expect(error.localizedDescription.contains(tmp.lastPathComponent))
+            #expect(!error.localizedDescription.contains("MetadataError error"))
+        }
     }
 
     // MARK: - FLAC


### PR DESCRIPTION
Refs #469

## Summary

A user adding cover art to an album saw "The operation couldn't be completed. (Library.EditError error 3.)". Code 3 is `.partial`: every file in the edit failed its own save. The wrapper's message carried only a count, and the per-file reason stored inside it was itself Foundation's fallback "(Metadata.MetadataError error N.)", because neither enum conformed to `LocalizedError`. The dialog could never have said anything useful.

Both enums now conform, with `errorDescription` returning their existing description, and `.partial` leads with the first concrete reason, so the dialog reads like "Edit: 12 file(s) failed. First: Metadata: file is read-only: 03 Track.mp3". A service-level test drives a cover-art patch at a read-only file and asserts the message names the file and the reason and carries no error code; the TagWriter read-only test asserts the same one layer down.

The reporter's actual reason is still unknown. The path works on a FLAC album on an internal disk with the embed setting both off and on (14 files, three saves, no `edit.track.failed`). This change makes the next report carry the reason; the reporter has been asked for the log line, the file format and the volume. The leading candidate is #472.

Gates: make format, make lint (0 violations), make build, make test-metadata (85), make test-library (391), make test-coverage (95%, 818 passes).

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: Not relevant. No observable state, view or timer changed. The only UI-visible effect is the text of the already-published `lastError` string, set once per failed save as before (`Modules/UI/Sources/UI/MetadataEditor/ViewModels/TagEditorViewModel.swift:234`).
2. What is the complexity in terms of library size?
   Answer: The `.partial` message now sorts the per-file error dictionary by track id to pick a stable first reason (`Modules/Library/Sources/Library/Edit/EditError.swift:36`): O(k log k) in the number of failed files, computed once when the message is built. A whole-library batch of 14,483 tracks all failing sorts 14k strings once, after 14k file rewrites have already happened. Negligible next to what precedes it.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: Not relevant. Nothing was created: no task, timer, cache or subscription. Two conformances and one computed property.
4. Which error paths propagate, recover, or fail loudly?
   Answer: This change is the error path. Per-file failures are caught, logged with `String(reflecting:)` and stored as `localizedDescription` (`EditTransaction.swift:87-90`); that stored string was opaque for `MetadataError` and is now its description. The batch then throws `.partial` (`EditTransaction.swift:175`), which propagates unchanged through the service to the view model, which shows `localizedDescription` (`TagEditorViewModel.swift:234`) and logs the reflected form (`:235`). No path recovers differently and nothing new fails loudly; the same errors now carry their reason. Verified end to end by `failedArtworkSaveReportsTheFileAndReasonNotAnErrorCode` against a read-only file.
5. What existing type or utility did you check before adding a new one?
   Answer: Checked that no module already adopted `LocalizedError` (`rg LocalizedError Modules/*/Sources`: none) and that `CustomNSError` was not needed, since the codes are not consumed anywhere. No new type; `errorDescription` reuses the existing `description`.
6. What did you stub, simplify, or leave incomplete?
   Answer: The root cause is unknown and untouched. This makes the next report carry it. When files fail for different reasons, the dialog shows only the first by track id; the log has all of them. The twelve sibling error enums with the same defect are not fixed here (#471).
7. What is the strongest argument that this is the wrong approach?
   Answer: The UI rule says strings owned by lower modules keep English raw values and get a UI-side display mapping; this ships module text straight into a dialog. Against that: the dialog already showed raw `localizedDescription`, as do the other 36 `localizedDescription` sites in UI and App, and these messages carry file names and reasons that cannot be pre-localized. A localized mapping is a real, larger change and belongs with the sibling enums (#471).

**What a user, or another module, would notice is different** (behaviour, not files):
- A failed tag or cover-art save now says which file failed and why, instead of "(Library.EditError error 3.)". The same applies to any dialog that shows a Metadata error, such as bulk actions and rating.
- For other modules, `localizedDescription` on these two enums now equals their `description`. No signature, case order or error code changed.

**Tried against a full-size library** (thousands of tracks, not a test fixture): no, because the change alters only error text and touches no performance surface; the service-level test exercises the real edit path against a real file, and the maintainer ran the cover-art save by hand on a 14-track album three times.

**Things noticed but not fixed here**: #471 (twelve sibling error enums lack `LocalizedError`), #472 (an art-only edit with embedding off still rewrites every audio file).
