### PR TITLE
chore(scripts): build vital-signs' Release timing outside the repo and keep git's fsmonitor out of it

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,4 +1,5 @@
 --swiftversion 6.0
+--exclude build,.build,DerivedData
 --self insert
 --stripunusedargs closure-only
 --wraparguments before-first

--- a/Scripts/vital-signs.sh
+++ b/Scripts/vital-signs.sh
@@ -69,6 +69,15 @@ CSV='docs/vital-signs.csv'
 ERR_FILE="$(mktemp)"
 trap 'rm -f "$ERR_FILE"' EXIT
 
+# Both slow steps make SwiftPM clone the package graph into a fresh folder.
+# With git's core.fsmonitor on (a common global setting with Homebrew git),
+# the checkout of a fresh clone can stall inside SwiftPM for good: seen twice
+# on 2026-09-10, once in Periphery's cache and once in TMPDIR, at zero CPU
+# with every package already cloned. Turning the monitor off for the git
+# those commands spawn, and nothing else, made the same build finish in two
+# minutes. It rides in the printed command so the reader can paste it.
+GIT_NO_FSMONITOR="GIT_CONFIG_PARAMETERS=\"'core.fsmonitor=false'\""
+
 RUN_DATE="$(date '+%Y-%m-%dT%H:%M')"
 RUN_COMMIT="$(git rev-parse --short HEAD)"
 RECORDED=0
@@ -237,7 +246,7 @@ unmeasured "Duplication percentage" \
 # read that file, so each number is a jq filter over the same scan. Findings
 # in test targets are excluded from the source rows by location.
 PERIPHERY_RESULTS='build/periphery-results.json'
-PERIPHERY_SCAN_CMD="periphery scan --quiet --format json > $PERIPHERY_RESULTS && jq length $PERIPHERY_RESULTS"
+PERIPHERY_SCAN_CMD="$GIT_NO_FSMONITOR periphery scan --quiet --format json > $PERIPHERY_RESULTS && jq length $PERIPHERY_RESULTS"
 PERIPHERY_SRC='select(.location | test("/Tests/|/UITests/") | not)'
 if ! command -v periphery >/dev/null; then
     unmeasured "Dead code · Periphery scan" "periphery is not installed" "$PERIPHERY_SCAN_CMD"
@@ -314,7 +323,11 @@ measure "ADRs with a status field" \
 # --- build and runtime -------------------------------------------------------
 
 section "Build and runtime"
-RELEASE_CMD="xcodebuild -project Bocan.xcodeproj -scheme Bocan -configuration Release -destination 'generic/platform=macOS' -derivedDataPath build/vital-signs-derived ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS= clean build"
+# Derived data goes outside the repo. A folder under build/ pulled the package
+# checkouts (swift-syntax and friends) inside the tree, and swiftformat walked
+# into them and failed on files that are not ours.
+RELEASE_DERIVED="${TMPDIR:-/tmp}/bocan-vital-signs-derived"
+RELEASE_CMD="$GIT_NO_FSMONITOR xcodebuild -project Bocan.xcodeproj -scheme Bocan -configuration Release -destination 'generic/platform=macOS' -derivedDataPath '$RELEASE_DERIVED' ARCHS=arm64 ONLY_ACTIVE_ARCH=NO CODE_SIGN_IDENTITY=- CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_ENTITLEMENTS= clean build"
 if (( SLOW )); then
     mkdir -p build
     start="$(date +%s)"


### PR DESCRIPTION
Follow-up to #470, two problems found by running `make vital-signs SLOW=1` on the maintainer's machine.

## 1. The slow build broke `make format`

The Release build used `build/vital-signs-derived` as its derived-data path, which pulls the package checkouts (swift-syntax and friends) inside the repo tree, and SwiftFormat walked into them and failed on files that are not ours ("The hoistTry and indent rules failed to terminate ... swift-syntax/Tests/SwiftParserTest/ExpressionTests.swift").

- `Scripts/vital-signs.sh`: the derived data now goes to `$TMPDIR/bocan-vital-signs-derived`, outside the repo. The printed command shows the real path, so it stays pasteable. The build log still lands in `build/`.
- `.swiftformat`: `--exclude build,.build,DerivedData`, so nothing that ever lands under those folders can break the formatter again. Verified by planting a misformatted Swift file under `build/` and running `swiftformat --lint .`: skipped, project file count unchanged at 1,187. SwiftLint already works from an `included:` list and never saw the folder.

## 2. Fresh package clones can hang SwiftPM when git's fsmonitor is on

Moving the build out of the repo exposed a second problem: the fresh out-of-repo build sat for 38 minutes at zero CPU inside SwiftPM's `GitRepository.checkout(revision:)` with all eleven packages already cloned. The Periphery scan had hung the same way earlier in the day in its own cache folder. Builds inside the repo tree never did.

The common factor is git's `core.fsmonitor`, on globally on this machine with Homebrew's git first on the path: every fresh clone SwiftPM makes starts a filesystem-monitor daemon, and that is where the checkout stalled. The identical build with `GIT_CONFIG_PARAMETERS="'core.fsmonitor=false'"` set for that command finished in 121 s.

- `Scripts/vital-signs.sh` now prefixes its xcodebuild and Periphery commands with that variable. It affects only the git those two commands spawn, never the user's config, and it rides in the printed command so the reader can paste it.

## Checks

- shellcheck clean.
- `Scripts/vital-signs.sh --slow` end to end from a clean TMPDIR: Release build and Periphery rows populated, nothing new under `build/` except the log and the Periphery results, `make format` green afterwards.

Not user-visible: `skip-changelog`.
