### PR TITLE
perf(ui): stop the tracks view and the root observing the whole lyrics model

### DIFF
--- a/App/LaunchLoadingView.swift
+++ b/App/LaunchLoadingView.swift
@@ -24,7 +24,6 @@ struct AppRootGate: View {
                 .environment(graph.dspViewModel)
                 .environment(\.settingsRouter, graph.settingsRouter)
                 .environmentObject(graph.windowMode)
-                .environmentObject(graph.lyricsViewModel)
                 .onAppear { graph.dockTile.start(observing: graph.libraryViewModel.nowPlaying) }
             } else if self.model.failed {
                 LaunchErrorView()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+The main window and the Songs list no longer redraw every time a synced lyric line changes, a lyrics fetch starts or finishes, or the sync offset moves. Only the lyrics pane updates on those moments, so playing a song with synced lyrics while the full Songs list is open stays smooth.
+
 Song lists from a Subsonic server, in the Songs view, album and artist pages and search results, no longer re-check every row whenever something else in the window updates, such as a synced lyric line changing. Large remote albums and playlists stay smooth.
 
 When saving tags or cover art fails, the message now says which file failed and why, such as the file being read-only, instead of an error code.

--- a/Modules/UI/Sources/UI/AppRoot/RootView.swift
+++ b/Modules/UI/Sources/UI/AppRoot/RootView.swift
@@ -19,7 +19,12 @@ import UniformTypeIdentifiers
 /// environment so deeply nested views can reach it directly.
 public struct BocanRootView: View {
     @StateObject private var vm: LibraryViewModel
-    @ObservedObject private var lyricsVM: LyricsViewModel
+    /// Plain reference (not @ObservedObject): the root only hands the model
+    /// to the lyrics pane, the playback driver and the environment. Observing
+    /// it re-ran this whole body, and every child that could not prove itself
+    /// unchanged, on each synced lyric line (#456). The pane toggle reads the
+    /// same preference key through `lyricsPaneVisible` below.
+    private let lyricsVM: LyricsViewModel
     @ObservedObject private var visualizerVM: VisualizerViewModel
     /// Plain reference (not @ObservedObject) so `BocanRootView` skips
     /// scrobble-settings re-renders; only `RecentScrobblesView` subscribes.
@@ -46,6 +51,11 @@ public struct BocanRootView: View {
     /// window content keeps it current. Read for the toolbar label and to
     /// reopen the window after bootstrap when it was left open.
     @AppStorage(ImmersiveView.preferenceKey) private var immersiveOpen = false
+    /// Mirrors `LyricsViewModel.paneVisible` (`@AppStorage("lyrics.paneVisible")`)
+    /// for the toolbar toggle, the same way the View menu does, so the root
+    /// re-renders when the pane opens or closes and not when a lyric line
+    /// changes (#456). Both sides read and write one UserDefaults key.
+    @AppStorage("lyrics.paneVisible") private var lyricsPaneVisible = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     public init(
@@ -96,7 +106,7 @@ public struct BocanRootView: View {
                         vm: self.vm,
                         miniPlayerOpen: self.windowMode.miniPlayerOpen,
                         toggleMiniPlayer: { self.windowMode.toggleMiniPlayer() },
-                        lyricsPaneVisible: self.$lyricsVM.paneVisible,
+                        lyricsPaneVisible: self.$lyricsPaneVisible,
                         visualizerPaneVisible: self.$visualizerVM.paneVisible,
                         immersiveOpen: self.immersiveOpen,
                         toggleImmersive: {
@@ -142,6 +152,7 @@ public struct BocanRootView: View {
             }
         }
         .environmentObject(self.vm)
+        .environment(\.lyricsViewModel, self.lyricsVM)
         .task {
             // Wire window openers before any UI loads.
             let ow = self.openWindow

--- a/Modules/UI/Sources/UI/Browse/TracksView+Actions.swift
+++ b/Modules/UI/Sources/UI/Browse/TracksView+Actions.swift
@@ -112,16 +112,20 @@ extension TracksView {
                 lib.setRating(stars: stars, for: tracks)
             },
             removeFromPlaylist: removeFromPlaylistAction,
-            editLyrics: { [lyricsEnv] track in
-                if let id = track.id {
-                    lyricsEnv.openEditor(for: id)
-                } else {
-                    lyricsEnv.openEditor()
+            editLyrics: self.lyricsViewModel.map { lyrics in
+                { track in
+                    if let id = track.id {
+                        lyrics.openEditor(for: id)
+                    } else {
+                        lyrics.openEditor()
+                    }
                 }
             },
-            fetchLyricsFromLRClib: self.lyricsEnv.lrclibEnabled ? { [lyricsEnv] track in
-                if let id = track.id {
-                    lyricsEnv.forceFetch(for: id)
+            fetchLyricsFromLRClib: self.lrclibEnabled ? self.lyricsViewModel.map { lyrics in
+                { track in
+                    if let id = track.id {
+                        lyrics.forceFetch(for: id)
+                    }
                 }
             } : nil
         )

--- a/Modules/UI/Sources/UI/Browse/TracksView.swift
+++ b/Modules/UI/Sources/UI/Browse/TracksView.swift
@@ -50,7 +50,17 @@ public struct TracksView: View {
     /// on `TracksViewModel`.  Pushed into the VM via `.onChange` below.
     @State var sortOrder: [KeyPathComparator<TrackRow>] = TracksViewModel.defaultSortOrder
 
-    @EnvironmentObject var lyricsEnv: LyricsViewModel
+    /// The lyrics model as a plain reference, never observed: nothing in this
+    /// view renders from its state, the two context-menu closures only call
+    /// into it. As an `@EnvironmentObject` it re-ran this body and the whole
+    /// subtree on every synced lyric line, fetch and offset change (#456).
+    /// `nil` in previews and tests, where the lyrics menu items are absent.
+    @Environment(\.lyricsViewModel) var lyricsViewModel
+
+    /// The one lyrics flag this view renders from (the LRClib menu item
+    /// exists only when the setting is on), observed on its own key so the
+    /// item follows Settings without a subscription to the whole model.
+    @AppStorage("lyrics.lrclibEnabled") var lrclibEnabled = false
 
     public init(
         vm: TracksViewModel,

--- a/Modules/UI/Sources/UI/Lyrics/LyricsViewModel.swift
+++ b/Modules/UI/Sources/UI/Lyrics/LyricsViewModel.swift
@@ -429,3 +429,14 @@ public enum LyricsFontSize: String, CaseIterable, Sendable {
         }
     }
 }
+
+/// Environment access to the shared ``LyricsViewModel`` as a plain reference.
+public extension EnvironmentValues {
+    /// The app-wide lyrics model, or `nil` where none was injected (previews,
+    /// tests). Views that only call into the model, such as a context menu's
+    /// "Edit Lyrics" action, read it from here instead of `@EnvironmentObject`,
+    /// so they never subscribe to its `objectWillChange` and do not re-render
+    /// on every synced lyric line (#456). Views that display lyrics state keep
+    /// observing the model directly.
+    @Entry var lyricsViewModel: LyricsViewModel?
+}

--- a/Modules/UI/Tests/UITests/LyricsObservationConventionTests.swift
+++ b/Modules/UI/Tests/UITests/LyricsObservationConventionTests.swift
@@ -1,0 +1,132 @@
+import Combine
+import Foundation
+import Library
+import Persistence
+import Testing
+@testable import UI
+
+// MARK: - LyricsObservationConventionTests
+
+/// #456: `TracksView` held the lyrics model as an `@EnvironmentObject` and
+/// `BocanRootView` as an `@ObservedObject`, so both re-ran, with every child
+/// that could not prove itself unchanged, on each synced lyric line, fetch and
+/// offset change. Neither renders lyrics state: the tracks view captures the
+/// model in two context-menu closures and reads one flag, the root hands the
+/// model on and binds the pane toggle. Observation scope cannot be exercised
+/// host-less, so these assert the wiring; the mirror test below checks the
+/// one runtime assumption the root's toggle makes.
+@Suite("Lyrics observation source conventions (#456)")
+struct LyricsObservationConventionTests {
+    private var moduleRoot: URL {
+        URL(filePath: #filePath)
+            .deletingLastPathComponent() // UITests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // Modules/UI/
+    }
+
+    private var repoRoot: URL {
+        self.moduleRoot
+            .deletingLastPathComponent() // Modules/
+            .deletingLastPathComponent() // repo
+    }
+
+    private func source(_ relativePath: String, from root: URL) throws -> String {
+        try String(contentsOf: root.appendingPathComponent(relativePath), encoding: .utf8)
+    }
+
+    /// Lines of code only: comments explaining the rule may name the wrapper.
+    private func codeLines(_ source: String) -> [String] {
+        source.split(separator: "\n", omittingEmptySubsequences: false)
+            .map { String($0) }
+            .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+    }
+
+    @Test("TracksView reads the lyrics model as a plain environment value and its one flag by key")
+    func tracksViewDoesNotObserveTheLyricsModel() throws {
+        let source = try self.source("Sources/UI/Browse/TracksView.swift", from: self.moduleRoot)
+        let code = self.codeLines(source)
+        #expect(!code.contains { $0.contains("@EnvironmentObject") || $0.contains("@ObservedObject") })
+        #expect(code.contains { $0.contains("@Environment(\\.lyricsViewModel) var lyricsViewModel") })
+        #expect(code.contains { $0.contains("@AppStorage(\"lyrics.lrclibEnabled\") var lrclibEnabled") })
+
+        let actions = try self.source("Sources/UI/Browse/TracksView+Actions.swift", from: self.moduleRoot)
+        #expect(!actions.contains("lyricsEnv"))
+        #expect(actions.contains("editLyrics: self.lyricsViewModel.map"))
+        #expect(actions.contains("fetchLyricsFromLRClib: self.lrclibEnabled ? self.lyricsViewModel.map"))
+    }
+
+    @Test("BocanRootView holds the lyrics model as a plain reference and mirrors the pane key for the toggle")
+    func rootHoldsAPlainReference() throws {
+        let source = try self.source("Sources/UI/AppRoot/RootView.swift", from: self.moduleRoot)
+        let code = self.codeLines(source)
+        #expect(code.contains { $0.contains("private let lyricsVM: LyricsViewModel") })
+        #expect(!code.contains { $0.contains("@ObservedObject private var lyricsVM") })
+        #expect(code.contains { $0.contains("@AppStorage(\"lyrics.paneVisible\") private var lyricsPaneVisible") })
+        #expect(code.contains { $0.contains("lyricsPaneVisible: self.$lyricsPaneVisible") })
+        #expect(!code.contains { $0.contains("$lyricsVM.paneVisible") })
+        #expect(code.contains { $0.contains(".environment(\\.lyricsViewModel, self.lyricsVM)") })
+    }
+
+    @Test("the mirrored keys are the model's own keys")
+    func mirroredKeysMatchTheModel() throws {
+        let model = try self.source("Sources/UI/Lyrics/LyricsViewModel.swift", from: self.moduleRoot)
+        #expect(model.contains("@AppStorage(\"lyrics.paneVisible\") public var paneVisible"))
+        #expect(model.contains("@AppStorage(\"lyrics.lrclibEnabled\") public private(set) var lrclibEnabled"))
+        #expect(model.contains("@Entry var lyricsViewModel: LyricsViewModel?"))
+    }
+
+    @Test("no view in the module takes the lyrics model as an @EnvironmentObject, and the app no longer injects one")
+    func noEnvironmentObjectSubscriberRemains() throws {
+        let sources = self.moduleRoot.appendingPathComponent("Sources/UI")
+        let enumerator = try #require(FileManager.default.enumerator(at: sources, includingPropertiesForKeys: nil))
+        var offenders: [String] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let text = try String(contentsOf: url, encoding: .utf8)
+            for line in self.codeLines(text)
+                where line.contains("@EnvironmentObject") && line.contains("LyricsViewModel") {
+                offenders.append("\(url.lastPathComponent): \(line.trimmingCharacters(in: .whitespaces))")
+            }
+        }
+        #expect(offenders.isEmpty, "a view subscribes to the whole lyrics model: \(offenders)")
+
+        let gate = try self.source("App/LaunchLoadingView.swift", from: self.repoRoot)
+        #expect(!gate.contains(".environmentObject(graph.lyricsViewModel)"))
+    }
+}
+
+// MARK: - LyricsPaneVisibleMirrorTests
+
+/// The root's toolbar toggle writes `lyrics.paneVisible` through its own
+/// `@AppStorage`, not through the model. The pane still decides its own
+/// visibility from `LyricsViewModel.paneVisible`, so a write through the
+/// defaults key must reach the model and publish, and a write from the model
+/// (auto-show, the editor opening) must land in the key the root reads.
+@Suite("Lyrics pane visibility mirror (#456)")
+@MainActor
+struct LyricsPaneVisibleMirrorTests {
+    private static let key = "lyrics.paneVisible"
+
+    @Test("a defaults write reaches the model and publishes; a model write lands in the defaults key")
+    func paneVisibleRoundTrips() async throws {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: Self.key)
+        defer { defaults.removeObject(forKey: Self.key) }
+
+        let db = try await Database(location: .inMemory)
+        let vm = LyricsViewModel(service: LyricsService(database: db, fetcher: nil))
+        #expect(!vm.paneVisible)
+
+        var emissions = 0
+        let sink = vm.objectWillChange.sink { emissions += 1 }
+        defer { sink.cancel() }
+
+        // The root's toggle: a write through the shared key.
+        defaults.set(true, forKey: Self.key)
+        #expect(vm.paneVisible, "the model reads the key the root wrote")
+        #expect(emissions >= 1, "the pane must be told to redraw when the key changes under it")
+
+        // The model's own writes (auto-show, openEditor) go the other way.
+        vm.paneVisible = false
+        #expect(!defaults.bool(forKey: Self.key), "the root's toolbar label follows the model's write")
+    }
+}


### PR DESCRIPTION
Closes #456

## Summary

`TracksView` held `LyricsViewModel` as an `@EnvironmentObject` for one flag (`lrclibEnabled`) and two context-menu closures, and `BocanRootView` held it as an `@ObservedObject` for the toolbar's pane-toggle binding. Both subscribed to the model's `objectWillChange`, so every synced lyric line, fetch start and end, editor presentation and offset slider move re-ran the root body and the whole tracks subtree. #450 slice 2 made the table's part of that re-render cheap; this stops the re-render.

- `LyricsViewModel` gains an `EnvironmentValues` entry, `\.lyricsViewModel`, an optional plain reference in the style of `\.settingsRouter`. The root injects it; previews and tests get `nil`, and the two lyrics menu items are simply absent there.
- `TracksView` reads the model through that entry (no subscription) and observes `lyrics.lrclibEnabled` on its own `@AppStorage` key, so the LRClib menu item still follows Settings. The two closures capture the model as before.
- `BocanRootView` holds the model as a plain `let` and binds the toolbar toggle to its own `@AppStorage("lyrics.paneVisible")`, the same mirror `BocanCommands` already uses for the View menu. The pane still decides its own visibility from the model.
- `App/LaunchLoadingView` no longer injects the model as an environment object; nothing consumed it that way any more.
- Tests: a runtime test pins the one assumption the mirror makes (a write through the defaults key reaches the model and publishes synchronously; a model write lands in the key the root reads). Source-convention tests pin the wiring, the shared key strings, and that no view in the module takes the model as an `@EnvironmentObject`.

Gates: make format, make lint (0 violations), make build, make test-ui (1,082 tests, 5 new), make test-coverage (passed).

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: Fewer. `TracksView` no longer subscribes to the lyrics model (`TracksView.swift:58` is a plain `@Environment` read, `:63` observes the one key it renders from), so a `@Published` change on the model (`LyricsViewModel.swift:17-49`: document, source, line index, offset, fetching, editor) no longer re-runs it or its subtree. It now re-runs on `lyrics.lrclibEnabled` changes, which are a Settings toggle. `BocanRootView` no longer observes the model (`RootView.swift:27`) and instead observes `lyrics.paneVisible` (`:58`), so it re-runs on a pane open or close, which is a user action or auto-show, not on a lyric line. `LyricsPane`, `LyricsView`, `LyricsEditorSheet`, `LyricsOffsetControl` and `ImmersiveView` keep observing the model; they render its state. One mechanism I cannot measure host-less: `@Environment` of a class value re-renders a dependent only if SwiftUI judges the value changed, and the injected reference is the same object for the life of the window (`RootView.swift:155`), so the environment read adds no re-renders of its own.
2. What is the complexity in terms of library size?
   Answer: Not relevant. No per-row or per-track work is added or removed; the change removes whole body evaluations. What is saved per lyric line is the `TracksView` body, its toolbar and `Group`, the `TrackTable` `updateNSView` call (which since #450 slice 2 exits through the plan's `.unchanged` path) and, from the root, every child that cannot prove itself unchanged. The saving does not grow with library size; the cost it avoided did, through the children that still had per-row work.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: Not relevant. No task, timer or subscription. The `@AppStorage` mirrors are SwiftUI-owned observations of a defaults key with the same lifetime as the view.
4. Which error paths propagate, recover, or fail loudly?
   Answer: Not relevant. Nothing on this path throws or logs. The one failure mode introduced is a missing environment injection, which degrades to an absent "Edit Lyrics" and "Fetch Lyrics from LRClib" menu item rather than the trap an `@EnvironmentObject` gives; the source-convention test checks the root injects it (`LyricsObservationConventionTests.swift`, "BocanRootView holds the lyrics model as a plain reference").
5. What existing type or utility did you check before adding a new one?
   Answer: The `EnvironmentValues` `@Entry` pattern already used for `settingsRouter` (`SettingsRouter.swift:62`) and `subsonicAnnotationCoordinator` (`SubsonicAnnotationCoordinator.swift:145`); the `@AppStorage` mirror of `lyrics.paneVisible` already in `BocanCommands.swift:18` and of `lyrics.lrclibEnabled` in `BocanCommands.swift:21` and `LyricsSettingsView.swift:13`. I also checked whether `LibraryViewModel` carried a lyrics reference that could be passed through instead (it does not), and that `editLyrics` and `fetchLyricsFromLRClib` were already optional with the menu section gated on them (`TrackTable.swift:63,66`, `TrackTableCoordinator+ContextMenu.swift:206`), so a `nil` model needs no new branch.
6. What did you stub, simplify, or leave incomplete?
   Answer: The environment value is injected on the root's window content (`RootView.swift:155`), so the root's sheets do not see it; no sheet builds a `TracksView` (the seven call sites are all under `ContentPane`), and a sheet that did would show no lyrics items rather than fail. The key strings `lyrics.paneVisible` and `lyrics.lrclibEnabled` are now written in three files each, tied together by a source-convention test rather than a shared constant. The issue's third step (comparable inputs for `TrackTable` so SwiftUI skips `updateNSView` itself) is not done; see below.
7. What is the strongest argument that this is the wrong approach?
   Answer: Reaching a view model through the environment as an unobserved reference is a pattern SwiftUI does not advertise, and a future reader may "fix" it back to `@EnvironmentObject`; the convention test is the guard. The explicit alternative, passing the flag and two closures into `TracksView` from each of its seven call sites, would be plainer but pushes lyrics knowledge into album, artist, playlist and smart-folder views that have none today. For the root, the tighter design is a toolbar view that observes the model itself, so the root never re-renders on a pane toggle either; but the toolbar is `ToolbarContent` built inside the root body, the toggle is a user action a few times a session, and the View menu already uses the same mirror, so the mirror is the smaller and consistent change.

**What a user, or another module, would notice is different** (behaviour, not files):
- Nothing visible. The Songs, album, artist, playlist and smart-folder lists render, sort and select as before. "Edit Lyrics" and "Fetch Lyrics from LRClib" are in the context menu as before, the LRClib item following the Settings switch. The toolbar's lyrics toggle opens and closes the pane with the same fade; the pane still auto-shows and opens with the editor.
- For other code: `\.lyricsViewModel` exists as an environment value; the App no longer injects `LyricsViewModel` as an environment object, so no view can take it as `@EnvironmentObject` (none did besides `TracksView`).

**Tried against a full-size library** (thousands of tracks, not a test fixture): no, because I cannot launch the app on the real library from here. Recipe: run the app from Xcode, open Songs with the full list loaded, show the lyrics pane, play a track with synced lyrics, and in Instruments (SwiftUI template, View Body track) watch the body counts for `TracksView` and `BocanRootView`: before this change they advanced with every lyric line, after it they should not move while the line highlight does.

**Things noticed but not fixed here**: the issue's third step, comparable inputs on `TrackTable` so SwiftUI skips `updateNSView` when nothing changed, with the plan as a fallback; proposed as its own issue (see PR discussion).
