### PR TITLE
fix(podcasts): upgrade plain-http feed URLs to https and surface real error reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+Adding a podcast whose directory listing gives a plain-http feed address now works when the show is also served securely, which most are. When it is not, the message says the feed is unencrypted-only instead of showing an error number. Any podcast error now shows its real reason.
+
 The main window and the Songs list no longer redraw every time a synced lyric line changes, a lyrics fetch starts or finishes, or the sync offset moves. Only the lyrics pane updates on those moments, so playing a song with synced lyrics while the full Songs list is open stays smooth.
 
 Song lists from a Subsonic server, in the Songs view, album and artist pages and search results, no longer re-check every row whenever something else in the window updates, such as a synced lyric line changing. Large remote albums and playlists stay smooth.

--- a/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
@@ -31,31 +31,61 @@ public actor FeedFetcher {
 
     /// Conditional GET for a feed URL.
     ///
-    /// Plain-http feed URLs are upgraded to https before the request unless the
-    /// host is loopback (local dev feeds, E2E fixtures). App Transport Security
-    /// blocks plain http on real hosts, and iTunes/Podcast Index search rows
-    /// still return http-only `feedUrl`s for older podcasts. The https variant
-    /// of such feeds serves identical content and validators, so stored etags
-    /// and Last-Modified stamps stay consistent.
+    /// A plain-http URL is tried over https first: App Transport Security
+    /// refuses plain http to internet hosts, and the directories still list
+    /// http-only `feedUrl`s for older shows whose https twin serves the same
+    /// feed and validators. If the https attempt fails with a network or HTTP
+    /// error, the URL is retried exactly as given and ATS decides: it lets
+    /// plain http through to the local network and loopback, and refuses it
+    /// for internet hosts, which surfaces as `insecureFeedUnsupported`.
+    /// Loopback hosts skip the https attempt (E2E fixtures, a local dev feed).
     ///
     /// - Parameters:
     ///   - url: The feed URL to fetch.
     ///   - etag: Previously stored ETag validator, if any.
     ///   - lastModified: Previously stored Last-Modified validator, if any.
     /// - Returns: `FeedFetchResult` with either fresh data or `notModified == true`.
-    /// - Throws: `PodcastsError.network`, `.httpStatus`, `.feedTooLarge`, or `CancellationError`.
+    /// - Throws: `PodcastsError.network`, `.httpStatus`, `.feedTooLarge`,
+    ///   `.insecureFeedUnsupported`, or `CancellationError`.
     public func fetch(_ url: URL, etag: String?, lastModified: String?) async throws -> FeedFetchResult {
         try Task.checkCancellation()
 
-        let fetchURL = Self.httpsUpgraded(url)
-        if fetchURL != url {
-            self.log.debug("feed.fetch.schemeUpgraded", [
-                "from": url.absoluteString,
-                "to": fetchURL.absoluteString,
-            ])
+        let upgraded = Self.httpsUpgraded(url)
+        guard upgraded != url else {
+            return try await self.perform(url, etag: etag, lastModified: lastModified)
         }
 
-        var request = URLRequest(url: fetchURL, timeoutInterval: 20)
+        self.log.debug("feed.fetch.schemeUpgraded", ["from": url.absoluteString, "to": upgraded.absoluteString])
+        do {
+            return try await self.perform(upgraded, etag: etag, lastModified: lastModified)
+        } catch let error as PodcastsError {
+            switch error {
+            case .network, .httpStatus:
+                // The secure twin does not serve this feed. Try the URL as
+                // given; a larger-than-cap feed is not retried, it would only
+                // download the same bytes again.
+                self.log.debug("feed.fetch.retryOriginal", [
+                    "url": url.absoluteString,
+                    "httpsError": String(reflecting: error),
+                ])
+
+            default:
+                throw error
+            }
+        }
+
+        do {
+            return try await self.perform(url, etag: etag, lastModified: lastModified)
+        } catch let PodcastsError.network(underlying)
+            where (underlying as? URLError)?.code == .appTransportSecurityRequiresSecureConnection {
+            self.log.warning("feed.fetch.insecureOnly", ["url": url.absoluteString])
+            throw PodcastsError.insecureFeedUnsupported(feedURL: url)
+        }
+    }
+
+    /// One conditional GET of exactly `url`, no scheme rewriting.
+    private func perform(_ url: URL, etag: String?, lastModified: String?) async throws -> FeedFetchResult {
+        var request = URLRequest(url: url, timeoutInterval: 20)
         request.setValue(UserAgent.string, forHTTPHeaderField: "User-Agent")
         request.setValue(
             "application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8",
@@ -68,7 +98,7 @@ public actor FeedFetcher {
             request.setValue(lastModified, forHTTPHeaderField: "If-Modified-Since")
         }
 
-        self.log.debug("feed.fetch.start", ["url": fetchURL.absoluteString])
+        self.log.debug("feed.fetch.start", ["url": url.absoluteString])
 
         let data: Data
         let response: URLResponse
@@ -77,7 +107,7 @@ public actor FeedFetcher {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            self.log.error("feed.fetch.failed", ["url": fetchURL.absoluteString, "error": String(reflecting: error)])
+            self.log.error("feed.fetch.failed", ["url": url.absoluteString, "error": String(reflecting: error)])
             throw PodcastsError.network(underlying: error)
         }
 
@@ -85,11 +115,11 @@ public actor FeedFetcher {
             throw PodcastsError.network(underlying: URLError(.badServerResponse))
         }
 
-        let finalURL = response.url ?? fetchURL
+        let finalURL = response.url ?? url
 
         // 304 Not Modified.
         if http.statusCode == 304 {
-            self.log.debug("feed.fetch.notModified", ["url": fetchURL.absoluteString])
+            self.log.debug("feed.fetch.notModified", ["url": url.absoluteString])
             return FeedFetchResult(
                 data: nil,
                 notModified: true,
@@ -101,7 +131,7 @@ public actor FeedFetcher {
 
         // Non-2xx responses.
         guard (200 ..< 300).contains(http.statusCode) else {
-            self.log.error("feed.fetch.httpError", ["url": fetchURL.absoluteString, "status": http.statusCode])
+            self.log.error("feed.fetch.httpError", ["url": url.absoluteString, "status": http.statusCode])
             throw PodcastsError.httpStatus(code: http.statusCode, url: finalURL)
         }
 
@@ -116,7 +146,7 @@ public actor FeedFetcher {
             throw PodcastsError.feedTooLarge(bytes: data.count)
         }
 
-        self.log.debug("feed.fetch.end", ["url": fetchURL.absoluteString, "bytes": data.count])
+        self.log.debug("feed.fetch.end", ["url": url.absoluteString, "bytes": data.count])
 
         return FeedFetchResult(
             data: data,
@@ -127,8 +157,8 @@ public actor FeedFetcher {
         )
     }
 
-    /// Upgrades a plain-http feed URL to https, except loopback hosts.
-    /// Returns the input URL unchanged for non-http schemes or loopback.
+    /// The https twin of a plain-http feed URL, or the URL unchanged for any
+    /// other scheme and for loopback hosts.
     static func httpsUpgraded(_ url: URL) -> URL {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               components.scheme?.lowercased() == "http",

--- a/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
@@ -31,6 +31,13 @@ public actor FeedFetcher {
 
     /// Conditional GET for a feed URL.
     ///
+    /// Plain-http feed URLs are upgraded to https before the request unless the
+    /// host is loopback (local dev feeds, E2E fixtures). App Transport Security
+    /// blocks plain http on real hosts, and iTunes/Podcast Index search rows
+    /// still return http-only `feedUrl`s for older podcasts. The https variant
+    /// of such feeds serves identical content and validators, so stored etags
+    /// and Last-Modified stamps stay consistent.
+    ///
     /// - Parameters:
     ///   - url: The feed URL to fetch.
     ///   - etag: Previously stored ETag validator, if any.
@@ -40,7 +47,15 @@ public actor FeedFetcher {
     public func fetch(_ url: URL, etag: String?, lastModified: String?) async throws -> FeedFetchResult {
         try Task.checkCancellation()
 
-        var request = URLRequest(url: url, timeoutInterval: 20)
+        let fetchURL = Self.httpsUpgraded(url)
+        if fetchURL != url {
+            self.log.debug("feed.fetch.schemeUpgraded", [
+                "from": url.absoluteString,
+                "to": fetchURL.absoluteString,
+            ])
+        }
+
+        var request = URLRequest(url: fetchURL, timeoutInterval: 20)
         request.setValue(UserAgent.string, forHTTPHeaderField: "User-Agent")
         request.setValue(
             "application/rss+xml, application/atom+xml, application/xml;q=0.9, */*;q=0.8",
@@ -53,7 +68,7 @@ public actor FeedFetcher {
             request.setValue(lastModified, forHTTPHeaderField: "If-Modified-Since")
         }
 
-        self.log.debug("feed.fetch.start", ["url": url.absoluteString])
+        self.log.debug("feed.fetch.start", ["url": fetchURL.absoluteString])
 
         let data: Data
         let response: URLResponse
@@ -62,7 +77,7 @@ public actor FeedFetcher {
         } catch is CancellationError {
             throw CancellationError()
         } catch {
-            self.log.error("feed.fetch.failed", ["url": url.absoluteString, "error": String(reflecting: error)])
+            self.log.error("feed.fetch.failed", ["url": fetchURL.absoluteString, "error": String(reflecting: error)])
             throw PodcastsError.network(underlying: error)
         }
 
@@ -70,11 +85,11 @@ public actor FeedFetcher {
             throw PodcastsError.network(underlying: URLError(.badServerResponse))
         }
 
-        let finalURL = response.url ?? url
+        let finalURL = response.url ?? fetchURL
 
         // 304 Not Modified.
         if http.statusCode == 304 {
-            self.log.debug("feed.fetch.notModified", ["url": url.absoluteString])
+            self.log.debug("feed.fetch.notModified", ["url": fetchURL.absoluteString])
             return FeedFetchResult(
                 data: nil,
                 notModified: true,
@@ -86,7 +101,7 @@ public actor FeedFetcher {
 
         // Non-2xx responses.
         guard (200 ..< 300).contains(http.statusCode) else {
-            self.log.error("feed.fetch.httpError", ["url": url.absoluteString, "status": http.statusCode])
+            self.log.error("feed.fetch.httpError", ["url": fetchURL.absoluteString, "status": http.statusCode])
             throw PodcastsError.httpStatus(code: http.statusCode, url: finalURL)
         }
 
@@ -101,7 +116,7 @@ public actor FeedFetcher {
             throw PodcastsError.feedTooLarge(bytes: data.count)
         }
 
-        self.log.debug("feed.fetch.end", ["url": url.absoluteString, "bytes": data.count])
+        self.log.debug("feed.fetch.end", ["url": fetchURL.absoluteString, "bytes": data.count])
 
         return FeedFetchResult(
             data: data,
@@ -110,5 +125,17 @@ public actor FeedFetcher {
             lastModified: http.value(forHTTPHeaderField: "Last-Modified"),
             finalURL: finalURL
         )
+    }
+
+    /// Upgrades a plain-http feed URL to https, except loopback hosts.
+    /// Returns the input URL unchanged for non-http schemes or loopback.
+    static func httpsUpgraded(_ url: URL) -> URL {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+              components.scheme?.lowercased() == "http",
+              !FeedURL.isLoopback(host: components.host) else {
+            return url
+        }
+        components.scheme = "https"
+        return components.url ?? url
     }
 }

--- a/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
@@ -97,8 +97,8 @@ public enum FeedURL {
 
     /// True for loopback hosts (127.0.0.1, ::1, localhost). Used by
     /// `normalizedStorageURL` (skip TLS for same-machine servers) and by
-    /// `FeedFetcher` (keep plain http for loopback when fetching).
-    public static func isLoopback(host: String?) -> Bool {
+    /// `FeedFetcher` (no https attempt for loopback when fetching).
+    static func isLoopback(host: String?) -> Bool {
         switch host?.lowercased() {
         case "127.0.0.1", "::1", "[::1]", "localhost":
             true

--- a/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
@@ -95,7 +95,10 @@ public enum FeedURL {
         return components.url
     }
 
-    private static func isLoopback(host: String?) -> Bool {
+    /// True for loopback hosts (127.0.0.1, ::1, localhost). Used by
+    /// `normalizedStorageURL` (skip TLS for same-machine servers) and by
+    /// `FeedFetcher` (keep plain http for loopback when fetching).
+    public static func isLoopback(host: String?) -> Bool {
         switch host?.lowercased() {
         case "127.0.0.1", "::1", "[::1]", "localhost":
             true

--- a/Modules/Podcasts/Sources/Podcasts/PodcastsError.swift
+++ b/Modules/Podcasts/Sources/Podcasts/PodcastsError.swift
@@ -12,6 +12,9 @@ public enum PodcastsError: Error, Sendable, CustomStringConvertible, LocalizedEr
     case searchUnavailable(source: String, reason: String)
     case notFound(feedURL: URL)
     case keychain(OSStatus, String)
+    /// The feed is served over plain http only and App Transport Security
+    /// refused it (its https twin failed first). Nothing to retry.
+    case insecureFeedUnsupported(feedURL: URL)
 
     public var description: String {
         switch self {
@@ -35,6 +38,8 @@ public enum PodcastsError: Error, Sendable, CustomStringConvertible, LocalizedEr
             "Podcast not found: \(url)"
         case let .keychain(status, op):
             "Keychain error \(status) during \(op)"
+        case let .insecureFeedUnsupported(url):
+            "This feed is only served over unencrypted http, which is not fetched: \(url)"
         }
     }
 

--- a/Modules/Podcasts/Sources/Podcasts/PodcastsError.swift
+++ b/Modules/Podcasts/Sources/Podcasts/PodcastsError.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The single error type for the Podcasts module.
-public enum PodcastsError: Error, Sendable, CustomStringConvertible {
+public enum PodcastsError: Error, Sendable, CustomStringConvertible, LocalizedError {
     case invalidFeedURL(String)
     case network(underlying: Error)
     case httpStatus(code: Int, url: URL)
@@ -36,5 +36,12 @@ public enum PodcastsError: Error, Sendable, CustomStringConvertible {
         case let .keychain(status, op):
             "Keychain error \(status) during \(op)"
         }
+    }
+
+    /// Surfaced through `error.localizedDescription`. Without this conformance,
+    /// the runtime renders bare cases as "Podcasts.PodcastsError error 1." and
+    /// hides the underlying cause (e.g. an App Transport Security failure).
+    public var errorDescription: String? {
+        self.description
     }
 }

--- a/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
@@ -20,6 +20,20 @@ final class MockHTTPClient: HTTPClient, @unchecked Sendable {
     }
 }
 
+/// Thread-safe capture of requests seen by a mock handler.
+final class RequestRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var _requests: [URLRequest] = []
+
+    var requests: [URLRequest] {
+        self.lock.withLock { self._requests }
+    }
+
+    func record(_ request: URLRequest) {
+        self.lock.withLock { self._requests.append(request) }
+    }
+}
+
 private func makeHTTPResponse(
     url: URL = URL(string: "https://example.com/feed")!,
     status: Int,
@@ -205,5 +219,62 @@ struct FeedFetcherTests {
         } catch let PodcastsError.feedTooLarge(bytes) {
             #expect(bytes == 2000)
         }
+    }
+
+    @Test("Plain-http remote feed URL is upgraded to https before the request")
+    func plainHttpRemoteUpgradedToHttps() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        let body = "<?xml version='1.0'?><rss/>".data(using: .utf8)!
+        let expectedUpgraded = #require(URL(string: "https://podcast.example.org/feed?x=1"))
+        mock.handler = { request in
+            seen.record(request)
+            return (body, makeHTTPResponse(url: expectedUpgraded, status: 200))
+        }
+        let fetcher = FeedFetcher(http: mock)
+        let result = try await fetcher.fetch(
+            #require(URL(string: "http://podcast.example.org/feed?x=1")),
+            etag: nil,
+            lastModified: nil
+        )
+        let requested = #require(seen.requests.last?.url)
+        #expect(requested.scheme == "https")
+        #expect(requested.host == "podcast.example.org")
+        #expect(requested.path == "/feed")
+        #expect(requested.query == "x=1")
+        #expect(result.data == body)
+        #expect(result.finalURL == expectedUpgraded)
+    }
+
+    @Test("Loopback plain-http feed URL is kept as http")
+    func loopbackPlainHttpKept() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        let expectedKept = #require(URL(string: "http://127.0.0.1:8090/feed"))
+        mock.handler = { request in
+            seen.record(request)
+            return (Data("<rss/>".utf8), makeHTTPResponse(url: expectedKept, status: 200))
+        }
+        let fetcher = FeedFetcher(http: mock)
+        _ = try await fetcher.fetch(expectedKept, etag: nil, lastModified: nil)
+        let requested = #require(seen.requests.last?.url)
+        #expect(requested == expectedKept)
+        #expect(requested.scheme == "http")
+    }
+
+    @Test("httpsUpgraded leaves non-http schemes unchanged")
+    func httpsUpgradedNonHttp() {
+        let fileURL = URL(fileURLWithPath: "/tmp/feed.xml")
+        #expect(FeedFetcher.httpsUpgraded(fileURL) == fileURL)
+
+        var comps = URLComponents()
+        comps.scheme = "https"
+        comps.host = "example.org"
+        comps.path = "/feed"
+        guard let httpsURL = comps.url else {
+            Issue.record("https URL fixture failed to build")
+            return
+        }
+        #expect(FeedFetcher.httpsUpgraded(httpsURL) == httpsURL)
     }
 }

--- a/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
@@ -221,12 +221,12 @@ struct FeedFetcherTests {
         }
     }
 
-    @Test("Plain-http remote feed URL is upgraded to https before the request")
+    @Test("Plain-http remote feed URL is tried over https first, and once when that works")
     func plainHttpRemoteUpgradedToHttps() async throws {
         let mock = MockHTTPClient()
         let seen = RequestRecorder()
         let body = "<?xml version='1.0'?><rss/>".data(using: .utf8)!
-        let expectedUpgraded = #require(URL(string: "https://podcast.example.org/feed?x=1"))
+        let expectedUpgraded = try #require(URL(string: "https://podcast.example.org/feed?x=1"))
         mock.handler = { request in
             seen.record(request)
             return (body, makeHTTPResponse(url: expectedUpgraded, status: 200))
@@ -237,7 +237,8 @@ struct FeedFetcherTests {
             etag: nil,
             lastModified: nil
         )
-        let requested = #require(seen.requests.last?.url)
+        let requested = try #require(seen.requests.last?.url)
+        #expect(seen.requests.count == 1, "no retry when the https twin serves the feed")
         #expect(requested.scheme == "https")
         #expect(requested.host == "podcast.example.org")
         #expect(requested.path == "/feed")
@@ -246,18 +247,101 @@ struct FeedFetcherTests {
         #expect(result.finalURL == expectedUpgraded)
     }
 
-    @Test("Loopback plain-http feed URL is kept as http")
+    @Test("When the https twin fails to connect, the URL is retried as given and its answer returned")
+    func httpsConnectionFailureRetriesOriginal() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        let body = Data("<rss/>".utf8)
+        let original = try #require(URL(string: "http://192.168.1.10:8000/feed.xml"))
+        mock.handler = { request in
+            seen.record(request)
+            if request.url?.scheme == "https" {
+                throw URLError(.secureConnectionFailed)
+            }
+            return (body, makeHTTPResponse(url: original, status: 200))
+        }
+        let fetcher = FeedFetcher(http: mock)
+        let result = try await fetcher.fetch(original, etag: nil, lastModified: nil)
+        #expect(seen.requests.map(\.url?.scheme) == ["https", "http"])
+        #expect(seen.requests.last?.url == original)
+        #expect(result.data == body)
+        #expect(result.finalURL == original)
+    }
+
+    @Test("When the https twin answers 404, the URL is retried as given")
+    func httpsNotFoundRetriesOriginal() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        let original = try #require(URL(string: "http://feeds.example.org/show"))
+        mock.handler = { request in
+            seen.record(request)
+            if request.url?.scheme == "https" {
+                return (Data(), makeHTTPResponse(status: 404))
+            }
+            return (Data("<rss/>".utf8), makeHTTPResponse(url: original, status: 200))
+        }
+        let fetcher = FeedFetcher(http: mock)
+        let result = try await fetcher.fetch(original, etag: nil, lastModified: nil)
+        #expect(seen.requests.count == 2)
+        #expect(result.data == Data("<rss/>".utf8))
+    }
+
+    @Test("When the retry is refused by App Transport Security, the error says the feed is http-only")
+    func retryRefusedByATSIsInsecureFeedUnsupported() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        let original = try #require(URL(string: "http://podcast.example.org/rss"))
+        mock.handler = { request in
+            seen.record(request)
+            if request.url?.scheme == "https" {
+                throw URLError(.cannotConnectToHost)
+            }
+            throw URLError(.appTransportSecurityRequiresSecureConnection)
+        }
+        let fetcher = FeedFetcher(http: mock)
+        do {
+            _ = try await fetcher.fetch(original, etag: nil, lastModified: nil)
+            Issue.record("Expected insecureFeedUnsupported to be thrown")
+        } catch let PodcastsError.insecureFeedUnsupported(feedURL) {
+            #expect(feedURL == original)
+        }
+        #expect(seen.requests.map(\.url?.scheme) == ["https", "http"])
+    }
+
+    @Test("A feed over the size cap on https is not retried over http")
+    func oversizedHttpsIsNotRetried() async throws {
+        let mock = MockHTTPClient()
+        let seen = RequestRecorder()
+        mock.handler = { request in
+            seen.record(request)
+            return (Data(count: 100), makeHTTPResponse(status: 200, headers: ["Content-Length": "2000"]))
+        }
+        let fetcher = FeedFetcher(http: mock, maxBytes: 1024)
+        do {
+            _ = try await fetcher.fetch(
+                #require(URL(string: "http://podcast.example.org/rss")),
+                etag: nil, lastModified: nil
+            )
+            Issue.record("Expected feedTooLarge to be thrown")
+        } catch PodcastsError.feedTooLarge {
+            // expected
+        }
+        #expect(seen.requests.count == 1)
+    }
+
+    @Test("Loopback plain-http feed URL is fetched as http, with no https attempt")
     func loopbackPlainHttpKept() async throws {
         let mock = MockHTTPClient()
         let seen = RequestRecorder()
-        let expectedKept = #require(URL(string: "http://127.0.0.1:8090/feed"))
+        let expectedKept = try #require(URL(string: "http://127.0.0.1:8090/feed"))
         mock.handler = { request in
             seen.record(request)
             return (Data("<rss/>".utf8), makeHTTPResponse(url: expectedKept, status: 200))
         }
         let fetcher = FeedFetcher(http: mock)
         _ = try await fetcher.fetch(expectedKept, etag: nil, lastModified: nil)
-        let requested = #require(seen.requests.last?.url)
+        let requested = try #require(seen.requests.last?.url)
+        #expect(seen.requests.count == 1)
         #expect(requested == expectedKept)
         #expect(requested.scheme == "http")
     }

--- a/Modules/Podcasts/Tests/PodcastsTests/PodcastsErrorTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/PodcastsErrorTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+@testable import Podcasts
+
+@Suite("PodcastsError")
+struct PodcastsErrorTests {
+    /// Repro for the bare "Podcasts.PodcastsError error 1." rendering: a plain
+    /// enum error's `localizedDescription` is the runtime's case-index string.
+    /// `LocalizedError` conformance must surface the case description instead.
+    @Test("LocalizedError conformance surfaces the case description, not bare \"error 1\"")
+    func networkCaseLocalizedDescription() {
+        let underlying = URLError(.appTransportSecurityRequiresSecureConnection)
+        let error = PodcastsError.network(underlying: underlying)
+
+        #expect(error.errorDescription == error.description)
+        #expect(error.errorDescription?.hasPrefix("Network error:") == true)
+        #expect(error.errorDescription?.contains(underlying.localizedDescription) == true)
+        #expect(error.localizedDescription == error.description)
+        #expect(error.localizedDescription.contains("error 1") == false)
+    }
+
+    @Test("errorDescription matches description for representative cases")
+    func representativeCases() throws {
+        let parse = try PodcastsError.parseFailed(
+            url: #require(URL(string: "https://example.org/feed")),
+            reason: "truncated"
+        )
+        #expect(parse.errorDescription == parse.description)
+
+        let status = try PodcastsError.httpStatus(
+            code: 404,
+            url: #require(URL(string: "https://example.org/feed"))
+        )
+        #expect(status.errorDescription == status.description)
+        #expect(status.errorDescription?.hasPrefix("HTTP 404") == true)
+    }
+}

--- a/Modules/Podcasts/Tests/PodcastsTests/PodcastsErrorTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/PodcastsErrorTests.swift
@@ -33,5 +33,11 @@ struct PodcastsErrorTests {
         )
         #expect(status.errorDescription == status.description)
         #expect(status.errorDescription?.hasPrefix("HTTP 404") == true)
+
+        let insecure = try PodcastsError.insecureFeedUnsupported(
+            feedURL: #require(URL(string: "http://example.org/feed"))
+        )
+        #expect(insecure.localizedDescription.contains("unencrypted http"))
+        #expect(insecure.localizedDescription.contains("http://example.org/feed"))
     }
 }


### PR DESCRIPTION
## Summary

Adding a podcast from search failed with "Podcasts.PodcastsError error 1" when the directory listed a plain-http feed address. Verified from an app bundle: App Transport Security refuses plain http to internet hosts with URLError -1022, and Bòcan's Info.plist sets no ATS exception, so the raw `feedUrl` from iTunes could never be fetched. Of 1,880 feeds sampled from iTunes search, 34 come back as plain http; 24 of those serve the same feed over https, 10 do not.

- `FeedFetcher` tries the https twin of a plain-http URL first. If that fails with a network or HTTP error, it retries the URL as given and lets ATS decide: the local network, `.local` names and loopback go through, internet hosts are refused. A refusal becomes the new `PodcastsError.insecureFeedUnsupported`, whose text says the feed is unencrypted-only. Loopback skips the https attempt. A feed over the size cap is not retried.
- `PodcastsError` conforms to `LocalizedError`, so every podcast error shows its real reason instead of a case number (the same shape as #473; #471 tracks the other eleven enums).
- `FeedURL.isLoopback` stays internal; the fetcher is in the same module.
- Storage still rewrites http to https at subscribe time (`FeedURL.normalizedStorageURL`), so a feed on the local network cannot refresh yet. That is #487, kept separate.

Gates: make format, make lint, make build, make test-podcasts (158 tests, 5 new), make test-coverage.

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: Not relevant. No observation changes. The fetcher is called by the search detail path once per opened result, by subscribe once, and by the refresh scheduler per stale feed; the only new work is a second request when the https attempt of a plain-http URL fails (`FeedFetcher.swift:59-83`).
2. What is the complexity in terms of library size?
   Answer: Not relevant to the local library. Per feed: one request as before for https URLs and loopback; at most two for a plain-http URL, and two only while its https twin is broken.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: Not relevant. No task or timer. `Task.checkCancellation()` at the top of `fetch` is unchanged and `perform` rethrows `CancellationError` untouched (`FeedFetcher.swift:107-108`).
4. Which error paths propagate, recover, or fail loudly?
   Answer: The https attempt's `.network` and `.httpStatus` errors are logged at debug with the reason and recovered by the retry (`:63-70`); `.feedTooLarge` propagates without a retry (`:72-73`). The retry's ATS refusal is logged at warning and rethrown as `insecureFeedUnsupported` (`:78-82`); any other retry error propagates as before. The UI shows the error text verbatim under "Failed to load podcast details" (`PodcastDetailView.swift:233-237`), so the user now reads the cause.
5. What existing type or utility did you check before adding a new one?
   Answer: `FeedURL.normalizedStorageURL` already prefers https, which is why subscribe and refresh never hit this and the detail path did (`AppPodcastSearch.swift:34` fetches the raw URL, `:41` normalises only for the lookup). `FeedURL.isLoopback` is reused rather than a second host check. The error enum gains one case rather than a second error type.
6. What did you stub, simplify, or leave incomplete?
   Answer: The storage-time https rewrite is left as is (#487). The new error's text is English owned by the module, as the other cases are; a localised UI mapping is not added. The loopback exemption is the existing list (127.0.0.1, ::1, localhost), not the full ATS local-network rule; other local hosts pay one failed https attempt per fetch and then work.
7. What is the strongest argument that this is the wrong approach?
   Answer: The retry encodes the ATS policy indirectly: the only reason to retry plain http is that ATS permits it for local hosts, and the exemption list could instead be widened to what ATS exempts and the retry dropped. Against that: ATS's local-network rule is not documented precisely enough to copy, and letting the OS decide costs one failed connection on a broken https twin. The other argument is Pocket Casts' and AntennaPod's choice to switch the platform block off and support http-only feeds outright; that is one Info.plist key, app-wide, and a decision for the maintainer rather than this fix.

**What a user, or another module, would notice is different** (behaviour, not files):
- Tapping a search result whose feed address is plain http now opens its details when the show is also served over https. When it is not, the message reads "This feed is only served over unencrypted http, which is not fetched" with the address, instead of "error 1".
- Every podcast error shown in the UI now carries its real reason.
- For other code: `PodcastsError` has a new case; `FeedFetcher.fetch` may issue two requests for a plain-http URL; `FeedURL.isLoopback` is internal.

**Tried against a full-size library** (thousands of tracks, not a test fixture): no, because the change is in the podcast feed fetch and does not touch the music library. The reported case was reproduced against the live feed from a bundled probe, and the https twin was verified to serve the same ETag.

**Things noticed but not fixed here**: #487 (subscribe stores every feed as https, so a plain-http feed on the local network can never refresh).
