### PR TITLE
fix(podcasts): store the feed address that answered, so a plain-http feed on the local network keeps refreshing

### DIFF
--- a/App/AppPodcastSearch.swift
+++ b/App/AppPodcastSearch.swift
@@ -37,12 +37,15 @@ struct AppPodcastSearch: PodcastSearchProviding {
         }
         let parsed = try self.parser.parse(data, sourceURL: feedURL)
 
-        // Check subscription status.
-        let storedURL = FeedURL.normalizedStorageURL(feedURL)?.absoluteString
-            ?? feedURL.absoluteString
+        // Check subscription status. The row holds the address that answered
+        // (what subscribe stores) or, for a show subscribed before #487, the
+        // other scheme of it; the lookup matches either.
+        let answered = fetchResult.requestedURL
+        let storedURL = FeedURL.normalizedStorageURL(answered)?.absoluteString
+            ?? answered.absoluteString
         let existing: Podcast?
         do {
-            existing = try await self.podcastRepo.fetchByFeedURL(storedURL)
+            existing = try await self.podcastRepo.fetchByFeedURLIgnoringScheme(storedURL)
         } catch {
             AppLogger.make(.app).warning(
                 "podcastSearch.fetchByFeedURL.failed",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+A podcast served over plain http from a computer on your home network now keeps refreshing after you subscribe. If one you added earlier stopped updating, add it again by its address: it picks up where it left off, with its episodes and settings.
+
 Adding a podcast whose directory listing gives a plain-http feed address now works when the show is also served securely, which most are. When it is not, the message says the feed is unencrypted-only instead of showing an error number. Any podcast error now shows its real reason.
 
 The main window and the Songs list no longer redraw every time a synced lyric line changes, a lyrics fetch starts or finishes, or the sync offset moves. Only the lyrics pane updates on those moments, so playing a song with synced lyrics while the full Songs list is open stays smooth.

--- a/Modules/Persistence/Sources/Persistence/Repositories/PodcastRepository.swift
+++ b/Modules/Persistence/Sources/Persistence/Repositories/PodcastRepository.swift
@@ -177,6 +177,30 @@ public struct PodcastRepository: Sendable {
         }
     }
 
+    /// Fetches a podcast by feed URL whether its row holds the http or the
+    /// https form of the address; an exact match wins. A subscription stores
+    /// the address that answered, so a show added before #487 (always stored
+    /// as https) or reached later under the other scheme still resolves to
+    /// its one row.
+    public func fetchByFeedURLIgnoringScheme(_ feedURL: String) async throws -> Podcast? {
+        let candidates = Self.schemeVariants(of: feedURL)
+        return try await self.database.read { db in
+            let rows = try Podcast.filter(candidates.contains(Column("feed_url"))).fetchAll(db)
+            return rows.first { $0.feedURL == feedURL } ?? rows.first
+        }
+    }
+
+    /// `feedURL` and, for an http(s) address, the same address under the other scheme.
+    static func schemeVariants(of feedURL: String) -> [String] {
+        if feedURL.hasPrefix("https://") {
+            return [feedURL, "http://\(feedURL.dropFirst("https://".count))"]
+        }
+        if feedURL.hasPrefix("http://") {
+            return [feedURL, "https://\(feedURL.dropFirst("http://".count))"]
+        }
+        return [feedURL]
+    }
+
     /// Resolves a podcast by its cached-artwork SHA-256 (the Phone Sync
     /// `/v1/artwork/{hash}` fallback). Byte-identical art shared by several
     /// shows yields the same hash; any match points at the same file bytes.

--- a/Modules/Persistence/Tests/PersistenceTests/PodcastRepositoryTests.swift
+++ b/Modules/Persistence/Tests/PersistenceTests/PodcastRepositoryTests.swift
@@ -122,6 +122,28 @@ struct PodcastRepositoryTests {
         #expect(result == nil)
     }
 
+    @Test("fetchByFeedURLIgnoringScheme finds a row under the other scheme, and an exact match wins (#487)")
+    func fetchIgnoringScheme() async throws {
+        let db = try await makeDB()
+        let repo = PodcastRepository(database: db)
+        let httpsID = try await repo.insert(self.sample(feedURL: "https://example.test/feed.rss"))
+
+        #expect(try await repo.fetchByFeedURLIgnoringScheme("http://example.test/feed.rss")?.id == httpsID)
+        #expect(try await repo.fetchByFeedURLIgnoringScheme("https://example.test/feed.rss")?.id == httpsID)
+        #expect(try await repo.fetchByFeedURLIgnoringScheme("http://other.test/feed.rss") == nil)
+
+        let httpID = try await repo.insert(self.sample(feedURL: "http://example.test/feed.rss", title: "Twin"))
+        #expect(try await repo.fetchByFeedURLIgnoringScheme("http://example.test/feed.rss")?.id == httpID)
+        #expect(try await repo.fetchByFeedURLIgnoringScheme("https://example.test/feed.rss")?.id == httpsID)
+    }
+
+    @Test("schemeVariants pairs http with https and leaves other schemes alone")
+    func schemeVariants() {
+        #expect(PodcastRepository.schemeVariants(of: "http://a.test/f") == ["http://a.test/f", "https://a.test/f"])
+        #expect(PodcastRepository.schemeVariants(of: "https://a.test/f") == ["https://a.test/f", "http://a.test/f"])
+        #expect(PodcastRepository.schemeVariants(of: "feed://a.test/f") == ["feed://a.test/f"])
+    }
+
     @Test("delete removes the row")
     func deleteRow() async throws {
         let db = try await makeDB()

--- a/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedFetcher.swift
@@ -13,6 +13,10 @@ public struct FeedFetchResult: Sendable {
     public var lastModified: String?
     /// The final URL after following any redirects.
     public var finalURL: URL
+    /// The address whose request answered, before any redirect: the https
+    /// twin of a plain-http URL when that served the feed, otherwise the URL
+    /// as given. A subscription stores this, not `finalURL` (#487).
+    public var requestedURL: URL
 }
 
 /// Fetches a feed URL with conditional GET support.
@@ -125,7 +129,8 @@ public actor FeedFetcher {
                 notModified: true,
                 etag: http.value(forHTTPHeaderField: "ETag"),
                 lastModified: http.value(forHTTPHeaderField: "Last-Modified"),
-                finalURL: finalURL
+                finalURL: finalURL,
+                requestedURL: url
             )
         }
 
@@ -153,7 +158,8 @@ public actor FeedFetcher {
             notModified: false,
             etag: http.value(forHTTPHeaderField: "ETag"),
             lastModified: http.value(forHTTPHeaderField: "Last-Modified"),
-            finalURL: finalURL
+            finalURL: finalURL,
+            requestedURL: url
         )
     }
 

--- a/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
+++ b/Modules/Podcasts/Sources/Podcasts/FeedURL.swift
@@ -57,8 +57,15 @@ public enum FeedURL {
         return key
     }
 
-    /// The absolute URL to store: https-preferred, no trailing slash, no fragment.
-    /// Returns nil for non-http(s) inputs.
+    /// The absolute URL to store: scheme kept as given (lowercased), host
+    /// lowercased, no trailing slash, no fragment, no default port. Returns
+    /// nil for non-http(s) inputs.
+    ///
+    /// The scheme is deliberately not upgraded here. `FeedFetcher` tries
+    /// https first at fetch time and `PodcastService.subscribe` stores the
+    /// address that answered, so a feed on the local network, which App
+    /// Transport Security lets through over plain http, keeps a working
+    /// address instead of an https one its server never serves (#487).
     public static func normalizedStorageURL(_ url: URL) -> URL? {
         guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false),
               let scheme = components.scheme?.lowercased(),
@@ -66,13 +73,7 @@ public enum FeedURL {
             return nil
         }
 
-        // Prefer https -- except loopback, where TLS buys nothing (no network
-        // to eavesdrop on) and forcing it breaks any same-machine http-only
-        // server outright (E2E fixtures; a local dev feed). Real remote
-        // feeds are unaffected: this only fires for 127.0.0.1/::1/localhost.
-        if !Self.isLoopback(host: components.host) {
-            components.scheme = "https"
-        }
+        components.scheme = scheme
 
         // Lowercase host.
         components.host = components.host?.lowercased()
@@ -96,8 +97,8 @@ public enum FeedURL {
     }
 
     /// True for loopback hosts (127.0.0.1, ::1, localhost). Used by
-    /// `normalizedStorageURL` (skip TLS for same-machine servers) and by
-    /// `FeedFetcher` (no https attempt for loopback when fetching).
+    /// `FeedFetcher`, which makes no https attempt for loopback: TLS buys
+    /// nothing on the same machine (E2E fixtures, a local dev feed).
     static func isLoopback(host: String?) -> Bool {
         switch host?.lowercased() {
         case "127.0.0.1", "::1", "[::1]", "localhost":

--- a/Modules/Podcasts/Sources/Podcasts/PodcastService.swift
+++ b/Modules/Podcasts/Sources/Podcasts/PodcastService.swift
@@ -99,16 +99,23 @@ public actor PodcastService {
     }
 
     public func subscribe(feedURL: URL, indexHints: PodcastSearchResult? = nil) async throws -> Int64 {
-        guard let stored = FeedURL.normalizedStorageURL(feedURL) else {
+        guard let given = FeedURL.normalizedStorageURL(feedURL) else {
             throw PodcastsError.invalidFeedURL(feedURL.absoluteString)
         }
 
-        self.log.debug("podcast.subscribe.start", ["url": stored.absoluteString])
+        self.log.debug("podcast.subscribe.start", ["url": given.absoluteString])
 
-        let fetchResult = try await fetcher.fetch(stored, etag: nil, lastModified: nil)
+        let fetchResult = try await fetcher.fetch(given, etag: nil, lastModified: nil)
         guard let data = fetchResult.data else {
             throw PodcastsError.network(underlying: URLError(.badServerResponse))
         }
+
+        // Store the address that answered: the https twin when it served the
+        // feed, the given http address when only that works (a feed on the
+        // local network, #487). Not the redirect target: that is a move, and
+        // would change the show's identity.
+        let stored = FeedURL.normalizedStorageURL(fetchResult.requestedURL) ?? given
+        try await self.adoptStoredScheme(stored)
 
         let parsed = try parser.parse(data, sourceURL: stored)
 
@@ -777,12 +784,36 @@ public actor PodcastService {
         if let cached = idCache[key] {
             return cached
         }
-        guard let podcast = try await podcastRepo.fetchByFeedURL(key) else {
+        // Either scheme: a queue persisted before a subscription's stored
+        // scheme was adopted (#487) still carries the old address.
+        guard let podcast = try await podcastRepo.fetchByFeedURLIgnoringScheme(key) else {
             throw PodcastsError.notFound(feedURL: feedURL)
         }
         let id = podcast.id ?? 0
         self.idCache[key] = id
         return id
+    }
+
+    /// Moves a subscription stored under the other scheme of `stored` onto
+    /// `stored`, so the subscribe upsert updates that row (its episodes,
+    /// positions and settings stay) instead of adding a second subscription.
+    /// This is how a show stored as https before #487, whose server only
+    /// answers over http on the local network, is repaired by re-adding it.
+    /// Only ever moves to an address whose request just succeeded; App
+    /// Transport Security admits plain http only for local hosts.
+    private func adoptStoredScheme(_ stored: URL) async throws {
+        let key = stored.absoluteString
+        guard let existing = try await self.podcastRepo.fetchByFeedURLIgnoringScheme(key),
+              existing.feedURL != key else { return }
+        var moved = existing
+        moved.feedURL = key
+        try await self.podcastRepo.update(moved)
+        self.idCache[existing.feedURL] = nil
+        self.log.info("podcast.subscribe.schemeAdopted", [
+            "id": existing.id ?? 0,
+            "from": existing.feedURL,
+            "to": key,
+        ])
     }
 }
 

--- a/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/FeedFetcherTests.swift
@@ -245,6 +245,7 @@ struct FeedFetcherTests {
         #expect(requested.query == "x=1")
         #expect(result.data == body)
         #expect(result.finalURL == expectedUpgraded)
+        #expect(result.requestedURL == expectedUpgraded, "the https twin answered, so that is the address to store")
     }
 
     @Test("When the https twin fails to connect, the URL is retried as given and its answer returned")
@@ -266,6 +267,7 @@ struct FeedFetcherTests {
         #expect(seen.requests.last?.url == original)
         #expect(result.data == body)
         #expect(result.finalURL == original)
+        #expect(result.requestedURL == original, "only the given http address answered")
     }
 
     @Test("When the https twin answers 404, the URL is retried as given")
@@ -327,6 +329,17 @@ struct FeedFetcherTests {
             // expected
         }
         #expect(seen.requests.count == 1)
+    }
+
+    @Test("requestedURL is the address asked, finalURL the redirect target (#487)")
+    func requestedURLIsNotTheRedirectTarget() async throws {
+        let mock = MockHTTPClient()
+        let asked = try #require(URL(string: "https://feeds.example.org/show"))
+        let moved = try #require(URL(string: "https://new.example.org/show"))
+        mock.handler = { _ in (Data("<rss/>".utf8), makeHTTPResponse(url: moved, status: 200)) }
+        let result = try await FeedFetcher(http: mock).fetch(asked, etag: nil, lastModified: nil)
+        #expect(result.requestedURL == asked)
+        #expect(result.finalURL == moved)
     }
 
     @Test("Loopback plain-http feed URL is fetched as http, with no https attempt")

--- a/Modules/Podcasts/Tests/PodcastsTests/FeedURLTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/FeedURLTests.swift
@@ -78,11 +78,14 @@ struct FeedURLTests {
 
     // MARK: - normalizedStorageURL
 
-    @Test("http URL is upgraded to https in storage URL")
-    func httpUpgradedToHttps() throws {
-        let http = try #require(URL(string: "http://example.com/feed"))
+    @Test("http URL keeps its scheme in the storage URL (#487)")
+    func httpKeepsScheme() throws {
+        let http = try #require(URL(string: "http://192.168.1.10:8000/feed"))
         let stored = FeedURL.normalizedStorageURL(http)
-        #expect(stored?.scheme == "https")
+        #expect(
+            stored?.absoluteString == "http://192.168.1.10:8000/feed",
+            "a local-network feed that ATS allows over http must keep a working address"
+        )
     }
 
     @Test("fragment is removed from storage URL")
@@ -121,10 +124,10 @@ struct FeedURLTests {
         #expect(stored?.scheme == "http", "TLS buys nothing on loopback and would break a same-machine http-only server")
     }
 
-    @Test("non-loopback http URL is still upgraded to https")
-    func nonLoopbackHTTPStillUpgraded() throws {
-        let http = try #require(URL(string: "http://example.com/feed"))
-        let stored = FeedURL.normalizedStorageURL(http)
-        #expect(stored?.scheme == "https")
+    @Test("scheme and host are lowercased in the storage URL, path case kept")
+    func schemeAndHostLowercased() throws {
+        let url = try #require(URL(string: "HTTPS://Example.COM/Feed"))
+        let stored = FeedURL.normalizedStorageURL(url)
+        #expect(stored?.absoluteString == "https://example.com/Feed")
     }
 }

--- a/Modules/Podcasts/Tests/PodcastsTests/PodcastServiceTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/PodcastServiceTests.swift
@@ -226,6 +226,78 @@ struct PodcastServiceTests {
         #expect(episodes.count == 2)
     }
 
+    // MARK: Stored scheme (#487)
+
+    @Test("a feed that only answers over http on the local network is stored as http and refreshes (#487)")
+    func lanHTTPFeedStoredAsHTTP() async throws {
+        let bed = try await makeBed()
+        let rssData = try fixtureData(named: "rss-full.xml")
+        let lan = try #require(URL(string: "http://192.168.1.10:8000/feed.xml"))
+        bed.feedMock.handler = { request in
+            if request.url?.scheme == "https" {
+                throw URLError(.secureConnectionFailed)
+            }
+            return (rssData, HTTPURLResponse(url: lan, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let podcastID = try await bed.service.subscribe(feedURL: lan)
+        let stored = try await PodcastRepository(database: bed.db).fetch(id: podcastID)
+        #expect(stored.feedURL == "http://192.168.1.10:8000/feed.xml")
+
+        let outcome = try await bed.service.refresh(podcastID: podcastID)
+        #expect(outcome.notModified == false, "the stored address must still answer")
+    }
+
+    @Test("a plain-http listing whose https twin works is stored as https, one subscription under either scheme (#487)")
+    func httpListingWithTwinStoredAsHTTPS() async throws {
+        let bed = try await makeBed()
+        let rssData = try fixtureData(named: "rss-full.xml")
+        bed.feedMock.handler = { request in
+            let url = request.url ?? testFeedURL
+            return (rssData, HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+        let listed = try #require(URL(string: "http://example.com/feed.rss"))
+
+        let id1 = try await bed.service.subscribe(feedURL: listed)
+        let id2 = try await bed.service.subscribe(feedURL: testFeedURL)
+        let id3 = try await bed.service.subscribe(feedURL: listed)
+        #expect(id1 == id2)
+        #expect(id2 == id3)
+        let all = try await PodcastRepository(database: bed.db).fetchAllSubscribed()
+        #expect(all.map(\.feedURL) == ["https://example.com/feed.rss"])
+    }
+
+    @Test("a subscription stored as https that only answers over http moves to http when re-added, keeping its row (#487)")
+    func reAddAdoptsWorkingScheme() async throws {
+        let bed = try await makeBed()
+        let rssData = try fixtureData(named: "rss-full.xml")
+        let repo = PodcastRepository(database: bed.db)
+        // What the pre-#487 normaliser stored for a feed on the local network.
+        let legacyID = try await repo.insert(Podcast(
+            feedURL: "https://192.168.1.10:8000/feed.xml",
+            title: "Home Server Show",
+            author: nil,
+            addedAt: fixedNow.timeIntervalSince1970
+        ))
+        try await bed.service.setPlaybackSpeed(1.5, podcastID: legacyID)
+        let lan = try #require(URL(string: "http://192.168.1.10:8000/feed.xml"))
+        bed.feedMock.handler = { request in
+            if request.url?.scheme == "https" {
+                throw URLError(.secureConnectionFailed)
+            }
+            return (rssData, HTTPURLResponse(url: lan, statusCode: 200, httpVersion: nil, headerFields: nil)!)
+        }
+
+        let id = try await bed.service.subscribe(feedURL: lan)
+        #expect(id == legacyID)
+        #expect(try await repo.fetchAllSubscribed().count == 1)
+        let moved = try await repo.fetch(id: id)
+        #expect(moved.feedURL == "http://192.168.1.10:8000/feed.xml")
+        #expect(moved.playbackSpeed == 1.5, "user settings stay with the row")
+        let audio = try await bed.service.audioURL(feedURL: lan, episodeGUID: ep1GUID)
+        #expect(!audio.absoluteString.isEmpty, "playback resolves the show by its new address")
+    }
+
     @Test("directory IDs survive a refresh and the plain-ID subscribe overload stores them (#409)")
     func directoryIDsSurviveRefresh() async throws {
         let bed = try await makeBed()

--- a/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/NowPlayingViewModel.swift
@@ -706,7 +706,7 @@ private extension NowPlayingViewModel {
         self.nowPlayingSubsonicServerID = nil
         self.nowPlayingSubsonicSongID = nil
         let repo = PodcastRepository(database: self.database)
-        let podcast = try? await repo.fetchByFeedURL(feedURL.absoluteString)
+        let podcast = try? await repo.fetchByFeedURLIgnoringScheme(feedURL.absoluteString)
         self.podcastID = podcast?.id
         if let path = podcast?.artworkPath {
             self.artwork = await ArtworkLoader.shared.image(at: path)

--- a/Tests/AppTests/AppPodcastAdapterTests.swift
+++ b/Tests/AppTests/AppPodcastAdapterTests.swift
@@ -181,6 +181,29 @@ struct AppPodcastSearchTests {
         #expect(detail.alreadySubscribed)
         #expect(detail.podcastID == id)
     }
+
+    @Test("a show stored under the other scheme still reads as subscribed (#487)")
+    func detailMatchesEitherScheme() async throws {
+        let bed = try await makeBed()
+        let search = AppPodcastSearch(
+            searchService: PodcastSearchService(podcastIndex: nil, itunes: ITunesSearchClient(http: bed.http)),
+            fetcher: FeedFetcher(http: bed.http),
+            parser: FeedParser(),
+            podcastRepo: PodcastRepository(database: bed.db)
+        )
+        // The directory lists http; the https twin answers; the row holds http.
+        let id = try await PodcastRepository(database: bed.db).insert(Podcast(
+            feedURL: "http://example.test/feed.rss",
+            title: "Seam Show",
+            author: nil,
+            addedAt: 0
+        ))
+        let listed = try #require(URL(string: "http://example.test/feed.rss"))
+
+        let detail = try await search.detail(feedURL: listed, hint: nil)
+        #expect(detail.alreadySubscribed)
+        #expect(detail.podcastID == id)
+    }
 }
 
 // MARK: - AppPodcastResolver


### PR DESCRIPTION
Closes #487

## Summary

`FeedURL.normalizedStorageURL` rewrote every non-loopback feed to https before it was stored. App Transport Security lets plain http through to private addresses, `.local` names and unqualified hosts (measured from an app bundle during the #486 review), so a feed on a home server fetched fine at subscribe time, was stored as an https address its server never serves, and failed every refresh after.

- The normaliser keeps the scheme (lowercased); host, trailing slash, fragment and default-port rules are unchanged.
- `FeedFetchResult` gains `requestedURL`: the address whose request answered, before any redirect. `subscribe` stores that. For a directory-listed http feed whose https twin works, that is https, exactly what the old code stored, so existing rows keep matching. For a feed that only answers over http, it is the given http address.
- `PodcastRepository.fetchByFeedURLIgnoringScheme` matches a row holding either scheme, exact match first, over the existing unique index. The search detail's "already subscribed" check, `resolveID` and the now-playing lookup use it.
- `subscribe` moves a row stored under the other scheme onto the address that just answered, so re-adding a broken home-server show repairs its row (episodes, positions, settings) instead of adding a second subscription.

Gates: make format, make lint, make build, make test-persistence (332, 2 new), make test-podcasts (162, 4 new plus 2 rewritten), make test-ui (1,082), make test-coverage (95%, 1 new App test).

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: None. No observation is added or widened. `subscribe` gains one indexed lookup and, only when a row sits under the other scheme, one update (`PodcastService.swift:117-118`, `:804-816`). `resolveID` changes its query, not its frequency: it runs on a cache miss, as before (`:789`). The now-playing lookup runs once per podcast queue item, as before (`NowPlayingViewModel.swift:709`).
2. What is the complexity in terms of library size?
   Answer: Not relevant to the music library. The lookup is `feed_url IN (a, b)` on the unique index `podcasts_feed_url_idx` (`M023_Podcasts.swift:51`), two index probes per call regardless of subscription count (`PodcastRepository.swift:185-191`).
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: The in-actor `idCache` entry for the old address is removed when a row moves scheme (`PodcastService.swift:811`); `subscribe` then caches the new address after the upsert, as it already did. No task or timer.
4. Which error paths propagate, recover, or fail loudly?
   Answer: A failure to move the row propagates out of `subscribe` (`:810`), so the user sees a failed subscribe rather than a silent duplicate. The detail path's lookup failure is still caught and logged as a warning, as before (`AppPodcastSearch.swift:47-55`). The now-playing lookup keeps its existing `try?`; it is on the #459 audit list and left for that pass.
5. What existing type or utility did you check before adding a new one?
   Answer: `FeedURL.canonicalKey` is already scheme-less and is what OPML import and search dedupe use. Keying lookups on it would need a canonical-key column and a migration (schema discipline); two values against the existing `feed_url` index do the same job with no schema change. `FeedFetchResult.finalURL` exists but includes redirects, and storing a redirect target would change a show's identity, hence `requestedURL`.
6. What did you stub, simplify, or leave incomplete?
   Answer: Existing rows are not migrated. A home-server show stored as https before this change stays broken until the user re-adds it by address; the release note says so. A feed stored as http pays one failed https attempt on each refresh, because the fetcher always tries https first (#486); a server that refuses the connection answers at once, but a firewall that drops the packets costs the 20 s request timeout (`FeedFetcher.swift:92`) per refresh.
7. What is the strongest argument that this is the wrong approach?
   Answer: The issue asked to "keep the scheme the user or the directory gave"; this stores the scheme that answered instead, which differs for the common case of an http listing with a working https twin. The deviation is deliberate: storing the given http for an internet host would store an address ATS refuses, and it would stop matching the https rows every existing such subscription already holds, creating duplicates. The other argument is that a launch-time migration could probe every https subscription over http and heal them without the user doing anything; that means network probes of every subscription at launch and silent scheme changes, so repair is left to an explicit re-add.

**What a user, or another module, would notice is different** (behaviour, not files):
- A podcast served over plain http from a machine on the home network can be subscribed to and keeps refreshing.
- A home-server show added before this change, which has not refreshed since, is repaired by adding it again by its address; its episodes, positions and settings stay.
- A search result for a show already subscribed under the other scheme shows as subscribed, and subscribing again does not create a second copy.
- For other code: `FeedURL.normalizedStorageURL` no longer upgrades to https; `FeedFetchResult.requestedURL` and `PodcastRepository.fetchByFeedURLIgnoringScheme` are new.

**Tried against a full-size library** (thousands of tracks, not a test fixture): no, because the change is in podcast subscription storage, not the music library. The local-network case is covered by mocked tests; no plain-http feed server on a LAN was available in this session.

**Things noticed but not fixed here**: none new. The per-refresh https attempt for stored http feeds is described in answer 6.
