### PR TITLE
fix(errors): report the failures the app was swallowing instead of appearing to succeed

### DIFF
--- a/App/BocanApp.swift
+++ b/App/BocanApp.swift
@@ -718,10 +718,23 @@ extension BocanApp {
         let streamCacheDir = cachesRoot
             .appendingPathComponent("io.cloudcauldron.bocan", isDirectory: true)
             .appendingPathComponent("SubsonicStreams", isDirectory: true)
-        let subsonicStreamCache: SubsonicStreamCache? = try? SubsonicStreamCache(
-            configuration: SubsonicStreamCache.Configuration(rootDirectory: streamCacheDir),
-            loader: RemoteTrackLoader(transport: URLSessionHTTPTransport())
-        )
+        // Without the cache no Subsonic track can play this session, and every
+        // attempt fails downstream with a less specific error; the reason
+        // belongs in the log (#483). The nil fallback keeps the rest of the
+        // app working.
+        let subsonicStreamCache: SubsonicStreamCache?
+        do {
+            subsonicStreamCache = try SubsonicStreamCache(
+                configuration: SubsonicStreamCache.Configuration(rootDirectory: streamCacheDir),
+                loader: RemoteTrackLoader(transport: URLSessionHTTPTransport())
+            )
+        } catch {
+            log.error("subsonic.streamCache.init_failed", [
+                "dir": streamCacheDir.path,
+                "error": String(reflecting: error),
+            ])
+            subsonicStreamCache = nil
+        }
         let subsonicStreamResolver: SubsonicStreamResolver? = subsonicStreamCache.map {
             SubsonicStreamResolver(cache: $0, service: subsonicService, store: subsonicStore)
         }

--- a/Bocan.xcodeproj/project.pbxproj
+++ b/Bocan.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		E8AF40A589C876DD37C97F90 /* UnreadBadgeConventionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B72951328C27C527BD6A8465 /* UnreadBadgeConventionTests.swift */; };
 		E97F656EB92A9BEF410F136A /* TagEditorViewModelCoverArtTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEE4418B4A2222EEC024FF83 /* TagEditorViewModelCoverArtTests.swift */; };
 		E9D73AC4A0D73B8AB048FE22 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 2DB88DBD9C7383F071E14E0A /* PrivacyInfo.xcprivacy */; };
+		EAB1B489BD4473694CDDE069 /* SwallowedErrorAppConventionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4361211E957248CB040098FE /* SwallowedErrorAppConventionTests.swift */; };
 		ECA13424360831515F243CD3 /* RadioPlaybackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79DAC189FEF04CE2EA91285C /* RadioPlaybackTests.swift */; };
 		EED38E2ED81F316DC9BDBF40 /* TranscriptParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0FE7DB1923DB9DC1F10B783 /* TranscriptParserTests.swift */; };
 		EF3FEC556E45ED55DEAB730F /* libswresample.7.dylib in Resources */ = {isa = PBXBuildFile; fileRef = 452D1A2A108EDC18B8429221 /* libswresample.7.dylib */; };
@@ -315,6 +316,7 @@
 		41FD02C5D416F4CB4CF501D1 /* LibrarySidebarExpansionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LibrarySidebarExpansionTests.swift; sourceTree = "<group>"; };
 		430AA7B3DBF933B314BC0CEF /* FullScreenTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullScreenTests.swift; sourceTree = "<group>"; };
 		434A2E9E4FB2BF7D13DE2614 /* libavformat.63.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libavformat.63.dylib; sourceTree = "<group>"; };
+		4361211E957248CB040098FE /* SwallowedErrorAppConventionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwallowedErrorAppConventionTests.swift; sourceTree = "<group>"; };
 		4470393601A2962C1049BC3E /* GenresComposersSortConventionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenresComposersSortConventionTests.swift; sourceTree = "<group>"; };
 		44B97291AE1B414D3801ECF5 /* AppPodcastActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppPodcastActions.swift; sourceTree = "<group>"; };
 		452D1A2A108EDC18B8429221 /* libswresample.7.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libswresample.7.dylib; sourceTree = "<group>"; };
@@ -491,7 +493,7 @@
 		FD18A2E69E819F5845E511F3 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateController.swift; sourceTree = "<group>"; };
 		FE67437858D66E54A636A323 /* PhoneSyncViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneSyncViewModelTests.swift; sourceTree = "<group>"; };
 		FEA827D3E6864D7D11A6F8BE /* BocanCommands+CollectionViewMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BocanCommands+CollectionViewMenu.swift"; sourceTree = "<group>"; };
-		"TEMP_9C8F1D87-EF7B-476C-802D-16C34070561F" /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
+		"TEMP_0E7E7C63-8E14-4B9D-9635-7879D3511EE7" /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -972,6 +974,7 @@
 				46711AA081CC4DFC72DFE251 /* RecentScrobblesSheetFlagTests.swift */,
 				5ED57792C57E833ECFCE6DC3 /* SettingsMenuTests.swift */,
 				3D1CAA6A918DE471019AB205 /* SingleInstanceTests.swift */,
+				4361211E957248CB040098FE /* SwallowedErrorAppConventionTests.swift */,
 				33F66E36224B360425CC7481 /* ToolsMenuTests.swift */,
 				CA4345B74618EDB42D7A1E53 /* TrackMenuSelectAllTests.swift */,
 				377CDD783D5E45B2A404260D /* UpdateControllerConventionTests.swift */,
@@ -981,10 +984,10 @@
 			path = AppTests;
 			sourceTree = "<group>";
 		};
-		"TEMP_C9A01050-EDF2-4F1D-9BB1-6B3365A5FF15" /* bocan-music */ = {
+		"TEMP_3364ABF6-DFE8-4602-8035-6CBCA95F8831" /* bocan-music */ = {
 			isa = PBXGroup;
 			children = (
-				"TEMP_9C8F1D87-EF7B-476C-802D-16C34070561F" /* Secrets.xcconfig */,
+				"TEMP_0E7E7C63-8E14-4B9D-9635-7879D3511EE7" /* Secrets.xcconfig */,
 			);
 			path = "bocan-music";
 			sourceTree = "<group>";
@@ -1286,6 +1289,7 @@
 				D660F301BE49F78BD9E83A59 /* SubsonicSongNowPlayingSelectionTests.swift in Sources */,
 				7BC373783953DCFDB5666EAC /* SubsonicSourcesDiscoveryTests.swift in Sources */,
 				FA4C8DEB049C0AC717E785A5 /* SummaryRevealTests.swift in Sources */,
+				EAB1B489BD4473694CDDE069 /* SwallowedErrorAppConventionTests.swift in Sources */,
 				E97F656EB92A9BEF410F136A /* TagEditorViewModelCoverArtTests.swift in Sources */,
 				15E3D444F86A2C9F79E77A0C /* TestImage.swift in Sources */,
 				4B0E91A52204EF74A81ED572 /* ToolsMenuTests.swift in Sources */,
@@ -1432,7 +1436,7 @@
 		};
 		3E79DA1DC07FE3812FB54C0A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_9C8F1D87-EF7B-476C-802D-16C34070561F" /* Secrets.xcconfig */;
+			baseConfigurationReference = "TEMP_0E7E7C63-8E14-4B9D-9635-7879D3511EE7" /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = arm64;
@@ -1568,7 +1572,7 @@
 		};
 		D3B7E2D650BF9AC5F77082BA /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = "TEMP_9C8F1D87-EF7B-476C-802D-16C34070561F" /* Secrets.xcconfig */;
+			baseConfigurationReference = "TEMP_0E7E7C63-8E14-4B9D-9635-7879D3511EE7" /* Secrets.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = arm64;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+When something you ask for cannot be done, Bòcan now says so instead of looking as though it worked. Adding tracks to a playlist, loving a track, saving a log file, choosing cover art and disconnecting a scrobbling account all report a failure now, and so do the play, skip and seek controls on your keyboard, headphones, lock screen and Control Centre.
+
+Two quieter faults are fixed with them. A podcast episode or a song sent to your phone can no longer be recorded under the wrong fingerprint if the file cannot be read all the way through, which used to make a transfer fail with nothing to explain it. And a library scan that cannot read your library now stops and tells you, rather than treating the library as empty and re-importing everything.
+
 A podcast served over plain http from a computer on your home network now keeps refreshing after you subscribe. If one you added earlier stopped updating, add it again by its address: it picks up where it left off, with its episodes and settings.
 
 Adding a podcast whose directory listing gives a plain-http feed address now works when the show is also served securely, which most are. When it is not, the message says the feed is unencrypted-only instead of showing an error number. Any podcast error now shows its real reason.

--- a/Modules/Library/Sources/Library/Edit/EditTransaction.swift
+++ b/Modules/Library/Sources/Library/Edit/EditTransaction.swift
@@ -149,7 +149,7 @@ actor EditTransaction {
             // without this, saved art shows on the play bar (which reads the
             // track) but never in the list or the albums grid.
             if case let .some(.some(artData)) = patch.coverArt {
-                await self.linkAlbumArt(artData: artData, updates: updates.map(\.track))
+                try await self.linkAlbumArt(artData: artData, updates: updates.map(\.track))
             }
         }
 
@@ -181,12 +181,17 @@ actor EditTransaction {
     ///   album itself) → the user is editing the album's art: **replace** it.
     /// - Partial coverage (fixing one track of many) → fill a **missing**
     ///   album link only; never hijack deliberate album-level art.
-    private func linkAlbumArt(artData: Data, updates: [Track]) async {
+    /// Throws when the art cannot be cached: the user asked for this image, the
+    /// edit reported success, and swallowing the failure left the art nowhere
+    /// the album could show it (#481).
+    private func linkAlbumArt(artData: Data, updates: [Track]) async throws {
         let extracted = CoverArtExtractor.extract(from: [
             RawCoverArt(data: artData, mimeType: Self.mimeType(for: artData), pictureType: 3),
         ])
         // persist() is idempotent (content-hash keyed); reuse from step 7 is free.
-        guard let persisted = try? await self.coverArtCache.persist(extracted, source: "user") else { return }
+        let persisted = try await self.coverArtCache.persist(extracted, source: "user")
+        // nil means the bytes held no usable image, so there is nothing to link.
+        guard let persisted else { return }
 
         var touchedByAlbum: [Int64: Int] = [:]
         for track in updates {

--- a/Modules/Library/Sources/Library/ScanCoordinator.swift
+++ b/Modules/Library/Sources/Library/ScanCoordinator.swift
@@ -102,7 +102,26 @@ actor ScanCoordinator {
         // treated as new and re-imported (clearing their disabled flag).
         // Both quick and full scans seed so that deleted files are pruned in
         // either mode.
-        let allTracks = await (try? self.trackRepo.fetchAllIncludingDisabled()) ?? []
+        // A failed read must not read as an empty library: the seed is what
+        // makes deleted files prunable and keeps known files from looking new,
+        // so the scan stops here rather than re-importing everything and
+        // pruning nothing (#481).
+        let allTracks: [Track]
+        do {
+            allTracks = try await self.trackRepo.fetchAllIncludingDisabled()
+        } catch {
+            self.log.error("scan.seed_failed", ["error": String(reflecting: error)])
+            emit(.error(url: nil, error: error))
+            emit(.finished(ScanProgress.Summary(
+                inserted: 0,
+                updated: 0,
+                removed: 0,
+                skipped: 0,
+                errors: 1,
+                duration: ContinuousClock.now - start
+            )))
+            return
+        }
         // Normalize roots to filesystem paths with symlinks resolved (e.g.
         // `/var` → `/private/var`).  Without this, a root URL of
         // `file:///var/folders/...` never prefix-matches a stored track URL
@@ -292,8 +311,17 @@ actor ScanCoordinator {
             return .error
         }
 
-        // Check for conflict
-        let existingTrack = try? await trackRepo.fetchOne(fileURL: url.absoluteString)
+        // Check for conflict. A failed lookup must not read as "no such row":
+        // that is what protects a user-edited track from being overwritten by
+        // the scan, so the file is reported as an error and left alone (#481).
+        let existingTrack: Track?
+        do {
+            existingTrack = try await self.trackRepo.fetchOne(fileURL: url.absoluteString)
+        } catch {
+            self.log.error("scan.existing_lookup_failed", ["url": url.path, "error": String(reflecting: error)])
+            emit(.error(url: url, error: error))
+            return .error
+        }
         if let ex = existingTrack, let exID = ex.id, ex.userEdited {
             let resolution = ConflictResolver.resolve(existingTrackID: exID, userEdited: true)
             if case let .conflict(trackID) = resolution {

--- a/Modules/Library/Tests/LibraryTests/ScanCoordinatorTests.swift
+++ b/Modules/Library/Tests/LibraryTests/ScanCoordinatorTests.swift
@@ -37,6 +37,33 @@ private final class EventBox: @unchecked Sendable {
 struct ScanCoordinatorTests {
     // MARK: - Basic scan
 
+    @Test("a scan whose seed read fails stops and reports it, rather than treating the library as empty (#481)")
+    func scanSeedFailureStops() async throws {
+        let db = try await makeDB()
+        let coordinator = ScanCoordinator(database: db)
+        // The seed read fails the way a damaged database would.
+        try await db.write { db in
+            try db.execute(sql: "DROP TABLE tracks")
+        }
+
+        let box = EventBox()
+        try await coordinator.scan(roots: [(url: sampleLibraryURL, rootID: 1)], mode: .full) { box.append($0) }
+        let events = box.events
+
+        #expect(events.contains {
+            if case .error = $0 {
+                return true
+            }
+            return false
+        }, "a swallowed seed read leaves the scan looking successful")
+        #expect(!events.contains {
+            if case .processed = $0 {
+                return true
+            }
+            return false
+        }, "an empty seed would re-import every file and prune nothing")
+    }
+
     @Test("scan over empty root list emits started then finished")
     func scanEmptyRoots() async throws {
         let db = try await makeDB()

--- a/Modules/Library/Tests/LibraryTests/SwallowedErrorLibraryConventionTests.swift
+++ b/Modules/Library/Tests/LibraryTests/SwallowedErrorLibraryConventionTests.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Testing
+@testable import Library
+
+// MARK: - SwallowedErrorLibraryConventionTests
+
+/// #459: the `try?` audit found Library sites that carried on as if an
+/// operation had succeeded (`docs/audits/try-optional-audit.md`, class (c)).
+/// Two of them cannot be driven from a test without a database that fails
+/// mid-scan or an unwritable cover-art cache, so these pin the fixed shapes in
+/// the source instead.
+@Suite("Swallowed-error conventions in Library (#459)")
+struct SwallowedErrorLibraryConventionTests {
+    private func source(_ relativePath: String) throws -> String {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent() // LibraryTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // Modules/Library/
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("the scan's conflict lookup reports a failed read instead of reading it as a new file (#481)")
+    func conflictLookupReportsFailure() throws {
+        let source = try self.source("Sources/Library/ScanCoordinator.swift")
+        // Scoped to the import path: the removal sweep's own `try?` is a
+        // separate, still-open audit finding, not this one.
+        let start = try #require(source.range(of: "private func importOne("))
+        let end = try #require(source.range(of: "private static func canonicalPath("))
+        let importOne = String(source[start.lowerBound ..< end.lowerBound])
+
+        #expect(!importOne.contains("try? await self.trackRepo.fetchOne"))
+        #expect(importOne.contains("existingTrack = try await self.trackRepo.fetchOne(fileURL: url.absoluteString)"))
+        #expect(importOne.contains("scan.existing_lookup_failed"))
+    }
+
+    @Test("an edit that cannot cache the user's cover art fails rather than reporting success (#481)")
+    func albumArtPersistPropagates() throws {
+        let source = try self.source("Sources/Library/Edit/EditTransaction.swift")
+        #expect(!source.contains("try? await self.coverArtCache.persist("))
+        #expect(source.contains("let persisted = try await self.coverArtCache.persist(extracted, source: \"user\")"))
+        #expect(source.contains("private func linkAlbumArt(artData: Data, updates: [Track]) async throws {"))
+        #expect(source.contains("try await self.linkAlbumArt(artData: artData, updates: updates.map(\\.track))"))
+    }
+}

--- a/Modules/Playback/Sources/Playback/QueuePlayer.swift
+++ b/Modules/Playback/Sources/Playback/QueuePlayer.swift
@@ -1638,34 +1638,33 @@ public actor QueuePlayer: Transport {
     private func bindRemoteCommands(_ commands: RemoteCommands) async {
         await MainActor.run {
             commands.onPlay = { [weak self] in
-                guard let self else { return }
-                try? await self.play()
+                await self?.runRemote(.play)
             }
             commands.onPause = { [weak self] in
                 await self?.pause()
             }
             commands.onTogglePlayPause = { [weak self] in
-                await self?.togglePlayPause()
+                await self?.runRemote(.togglePlayPause)
             }
             commands.onNextTrack = { [weak self] in
-                try? await self?.next()
+                await self?.runRemote(.next)
             }
             commands.onPreviousTrack = { [weak self] in
-                try? await self?.previous()
+                await self?.runRemote(.previous)
             }
             commands.onSeek = { [weak self] time in
-                try? await self?.seek(to: time)
+                await self?.runRemote(.seek(time, label: "seek"))
             }
             commands.onSkipBack = { [weak self] interval in
                 guard let self else { return }
                 let current = await self.currentTime
-                try? await self.seek(to: max(0, current - interval))
+                await self.runRemote(.seek(max(0, current - interval), label: "skipBack"))
             }
             commands.onSkipForward = { [weak self] interval in
                 guard let self else { return }
                 let current = await self.currentTime
                 let dur = await self.duration
-                try? await self.seek(to: min(dur, current + interval))
+                await self.runRemote(.seek(min(dur, current + interval), label: "skipForward"))
             }
             commands.register()
         }
@@ -1673,11 +1672,85 @@ public actor QueuePlayer: Transport {
 
     // MARK: Convenience
 
-    private func togglePlayPause() async {
+    /// A transport command that arrived from outside the app: the lock screen,
+    /// a media key, headphone controls, Siri or the Control Centre widget.
+    enum RemoteCommand: Sendable {
+        case play
+        case togglePlayPause
+        case next
+        case previous
+        case seek(TimeInterval, label: String)
+
+        /// The name logged when the command fails.
+        var label: String {
+            switch self {
+            case .play:
+                "play"
+
+            case .togglePlayPause:
+                "togglePlayPause"
+
+            case .next:
+                "nextTrack"
+
+            case .previous:
+                "previousTrack"
+
+            case let .seek(_, label):
+                label
+            }
+        }
+    }
+
+    /// Runs a remote transport command, reporting a failure the way the in-app
+    /// buttons do.
+    ///
+    /// Those buttons surface their error because the view model that called
+    /// them catches it; a media key has no such caller, so these dropped the
+    /// error entirely and the key looked dead with nothing in the log (#482).
+    /// A failure is logged with the command name and pushed onto the state
+    /// stream, where `NowPlayingViewModel` already turns `.failed` into the
+    /// user's "playback stopped" toast.
+    func runRemote(_ command: RemoteCommand) async {
+        do {
+            switch command {
+            case .play:
+                try await self.play()
+
+            case .togglePlayPause:
+                try await self.performTogglePlayPause()
+
+            case .next:
+                try await self.next()
+
+            case .previous:
+                try await self.previous()
+
+            case let .seek(time, _):
+                try await self.seek(to: time)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            self.log.error("remote.command.failed", [
+                "command": command.label,
+                "error": String(reflecting: error),
+            ])
+            self.stateContinuation?.yield(.failed(Self.remoteFailure(error)))
+        }
+    }
+
+    /// The engine's own error where there is one, so the reason survives to the
+    /// state stream; anything else is wrapped the way the skip path wraps it.
+    private static func remoteFailure(_ error: any Error) -> AudioEngineError {
+        error as? AudioEngineError ?? .decoderFailure(codec: "unknown", underlying: error)
+    }
+
+    private func performTogglePlayPause() async throws {
         if case .playing = self.lastEmittedState {
             await self.pause()
         } else {
-            try? await self.play()
+            try await self.play()
         }
     }
 

--- a/Modules/Playback/Tests/PlaybackTests/QueuePlayerTests.swift
+++ b/Modules/Playback/Tests/PlaybackTests/QueuePlayerTests.swift
@@ -317,6 +317,80 @@ struct QueuePlayerTests {
 
     // MARK: - Helpers
 
+    // MARK: Remote commands (#482)
+
+    @Test("a remote transport command that fails reports a playback failure instead of dropping it (#482)")
+    func remoteCommandFailureIsReported() async throws {
+        let engine = AudioEngine()
+        let db = try await Database(location: .inMemory)
+        let player = QueuePlayer(engine: engine, database: db)
+        let repo = TrackRepository(database: db)
+        // The row points at a file that is not there, so the load fails the way
+        // a media key's play on a moved file does.
+        let ids = try await insertTestTracks(repo: repo, count: 1)
+        try await player.addToQueue(ids)
+        let items = await player.queue.items
+        await player.queue.replace(with: items, startAt: 0)
+
+        let reported = await Self.awaitFailure(from: player) {
+            await player.runRemote(.play)
+        }
+        #expect(reported, "the lock screen and the media keys have no caller to catch this")
+    }
+
+    @Test("every remote handler routes through runRemote rather than dropping its error (#482)")
+    func remoteHandlersDoNotSwallow() throws {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent() // PlaybackTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // Modules/Playback/
+            .appendingPathComponent("Sources/Playback/QueuePlayer.swift")
+        let source = try String(contentsOf: url, encoding: .utf8)
+        let start = try #require(source.range(of: "private func bindRemoteCommands"))
+        let end = try #require(source.range(of: "// MARK: Convenience"))
+        let block = String(source[start.lowerBound ..< end.lowerBound])
+
+        #expect(!block.contains("try?"), "a dropped error leaves the key looking dead with nothing logged")
+        for call in ["runRemote(.play)", "runRemote(.togglePlayPause)", "runRemote(.next)",
+                     "runRemote(.previous)", "runRemote(.seek("] {
+            #expect(block.contains(call), "missing \(call)")
+        }
+    }
+
+    @Test("a remote command is logged under its own name")
+    func remoteCommandLabels() {
+        #expect(QueuePlayer.RemoteCommand.play.label == "play")
+        #expect(QueuePlayer.RemoteCommand.next.label == "nextTrack")
+        #expect(QueuePlayer.RemoteCommand.previous.label == "previousTrack")
+        #expect(QueuePlayer.RemoteCommand.seek(3, label: "skipBack").label == "skipBack")
+    }
+
+    /// Runs `action` and reports whether a `.failed` state reaches the player's
+    /// state stream, which is where the now-playing strip's error toast hangs.
+    private static func awaitFailure(
+        from player: QueuePlayer,
+        action: @escaping @Sendable () async -> Void
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                for await state in player.state {
+                    if case .failed = state {
+                        return true
+                    }
+                }
+                return false
+            }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(5))
+                return false
+            }
+            await action()
+            let reported = await group.next() ?? false
+            group.cancelAll()
+            return reported
+        }
+    }
+
     private func makeTrack(n: Int) -> Track {
         let now = Int64(Date().timeIntervalSince1970)
         return Track(

--- a/Modules/Podcasts/Sources/Podcasts/Downloads/DownloadStore.swift
+++ b/Modules/Podcasts/Sources/Podcasts/Downloads/DownloadStore.swift
@@ -17,6 +17,8 @@ import Observability
 public struct DownloadStore: Sendable {
     private let root: URL
     private let log = AppLogger.make(.podcasts)
+    /// `contentHash(ofFileAt:)` is static, so it needs its own handle.
+    private static let log = AppLogger.make(.podcasts)
 
     /// - Parameter root: override the storage root (tests pass a temp directory).
     ///   `nil` uses the default Application Support location.
@@ -122,15 +124,30 @@ public struct DownloadStore: Sendable {
     }
 
     /// Streams the file at `url` through SHA-256 (without loading it whole into
-    /// memory) and returns the lowercase-hex digest, or `nil` if it cannot be
-    /// read. Computed once at download time and stored so Phone Sync need not
-    /// re-hash the file.
+    /// memory) and returns the lowercase-hex digest, or `nil` when the file
+    /// cannot be read. Computed once at download time and stored so Phone Sync
+    /// need not re-hash the file.
+    ///
+    /// A read error part-way through returns `nil`, never the digest of the
+    /// bytes read so far: that value is not this file's hash, and the phone
+    /// verifies the episode it fetches against it (#484).
     public static func contentHash(ofFileAt url: URL) -> String? {
-        guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+        guard let handle = try? FileHandle(forReadingFrom: url) else {
+            self.log.warning("download.contentHash.openFailed", ["file": url.lastPathComponent])
+            return nil
+        }
         defer { try? handle.close() }
         var hasher = SHA256()
-        while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
-            hasher.update(data: chunk)
+        do {
+            while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        } catch {
+            self.log.warning("download.contentHash.readFailed", [
+                "file": url.lastPathComponent,
+                "error": String(reflecting: error),
+            ])
+            return nil
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }

--- a/Modules/Podcasts/Tests/PodcastsTests/DownloadStoreTests.swift
+++ b/Modules/Podcasts/Tests/PodcastsTests/DownloadStoreTests.swift
@@ -23,6 +23,37 @@ struct DownloadStoreTests {
         #expect(!a.lastPathComponent.contains("/"))
     }
 
+    @Test("contentHash is the file's SHA-256 (#484)")
+    func contentHashMatchesTheFile() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DownloadStoreHash-\(UUID().uuidString).bin")
+        try Data("hello".utf8).write(to: file)
+        defer { try? FileManager.default.removeItem(at: file) }
+
+        #expect(
+            DownloadStore.contentHash(ofFileAt: file)
+                == "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+        )
+    }
+
+    @Test("contentHash is nil, not a partial digest, when the file cannot be read (#484)")
+    func contentHashNilWhenUnreadable() throws {
+        let missing = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DownloadStoreHash-missing-\(UUID().uuidString).bin")
+        #expect(DownloadStore.contentHash(ofFileAt: missing) == nil)
+
+        let unreadable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DownloadStoreHash-locked-\(UUID().uuidString).bin")
+        try Data("hello".utf8).write(to: unreadable)
+        try FileManager.default.setAttributes([.posixPermissions: 0o000], ofItemAtPath: unreadable.path)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: unreadable.path)
+            try? FileManager.default.removeItem(at: unreadable)
+        }
+
+        #expect(DownloadStore.contentHash(ofFileAt: unreadable) == nil)
+    }
+
     @Test("extension is derived from the MIME type, defaulting to mp3")
     func extensionFromMIME() {
         #expect(DownloadStore.fileExtension(forMIME: "audio/mpeg") == "mp3")

--- a/Modules/SyncServer/Sources/SyncServer/Http/ManifestRoutes.swift
+++ b/Modules/SyncServer/Sources/SyncServer/Http/ManifestRoutes.swift
@@ -15,8 +15,20 @@ enum ManifestRoutes {
     ) -> [Router.Route] {
         [
             Router.Route("GET", "/v1/ping", auth: .anyTLS) { _, _ in
-                let serverId = await (try? syncMeta.serverId()) ?? ""
-                let generation = await (try? syncMeta.generation()) ?? 0
+                // A ping that cannot read the identity answers 500. Answering
+                // 200 with an empty id and generation 0 tells the phone it is
+                // talking to a different Mac that has never changed (#485).
+                let serverId: String
+                let generation: Int
+                do {
+                    serverId = try await syncMeta.serverId()
+                    generation = try await syncMeta.generation()
+                } catch {
+                    AppLogger.make(.sync).error("sync.ping.identityUnavailable", [
+                        "error": String(reflecting: error),
+                    ])
+                    return .error(.internal, message: "Server identity unavailable", status: 500)
+                }
                 let escaped = serverId
                     .replacingOccurrences(of: "\\", with: "\\\\")
                     .replacingOccurrences(of: "\"", with: "\\\"")

--- a/Modules/SyncServer/Sources/SyncServer/Manifest/ManifestBuilder.swift
+++ b/Modules/SyncServer/Sources/SyncServer/Manifest/ManifestBuilder.swift
@@ -164,7 +164,7 @@ public struct ManifestBuilder: Sendable {
         let sha256: String
         if let stored = state.contentHash {
             sha256 = stored
-        } else if let computed = Self.hashFile(fileURL) {
+        } else if let computed = self.hashFile(fileURL) {
             sha256 = computed
         } else {
             // The download is gone; without the bytes we cannot serve or hash it.
@@ -198,13 +198,27 @@ public struct ManifestBuilder: Sendable {
         return hash
     }
 
-    /// Streams a file through SHA-256 without loading it whole into memory.
-    private static func hashFile(_ url: URL) -> String? {
+    /// Streams a file through SHA-256 without loading it whole into memory,
+    /// or `nil` when it cannot be read.
+    ///
+    /// A read error part-way through returns `nil`, never the digest of the
+    /// bytes read so far: the phone verifies the file it fetches against this
+    /// value, and an episode with no hash is left out of the manifest rather
+    /// than advertised under a wrong one (#485).
+    private func hashFile(_ url: URL) -> String? {
         guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
         defer { try? handle.close() }
         var hasher = SHA256()
-        while let chunk = try? handle.read(upToCount: 1 << 20), !chunk.isEmpty {
-            hasher.update(data: chunk)
+        do {
+            while let chunk = try handle.read(upToCount: 1 << 20), !chunk.isEmpty {
+                hasher.update(data: chunk)
+            }
+        } catch {
+            self.log.warning("manifest.hashFile.readFailed", [
+                "file": url.lastPathComponent,
+                "error": String(reflecting: error),
+            ])
+            return nil
         }
         return hasher.finalize().map { String(format: "%02x", $0) }.joined()
     }

--- a/Modules/SyncServer/Sources/SyncServer/Pairing/PairingCoordinator.swift
+++ b/Modules/SyncServer/Sources/SyncServer/Pairing/PairingCoordinator.swift
@@ -32,7 +32,9 @@ public actor PairingCoordinator {
     private let trusted: TrustedDevices
     private let ui: any PairingUIBridge
     private let serverName: @Sendable () -> String
-    private let serverId: @Sendable () async -> String
+    /// Throwing: a pairing that cannot read the server id fails instead of
+    /// handing the phone an empty one as this Mac's identity (#485).
+    private let serverId: @Sendable () async throws -> String
     private let now: @Sendable () -> Date
     private let timeout: TimeInterval
     private let log = AppLogger.make(.sync)
@@ -47,7 +49,7 @@ public actor PairingCoordinator {
         trusted: TrustedDevices,
         ui: any PairingUIBridge,
         serverName: @escaping @Sendable () -> String,
-        serverId: @escaping @Sendable () async -> String,
+        serverId: @escaping @Sendable () async throws -> String,
         timeout: TimeInterval = 120,
         now: @escaping @Sendable () -> Date = Date.init
     ) {
@@ -184,8 +186,10 @@ public actor PairingCoordinator {
             deviceName: session.deviceName,
             pairedAt: self.now().timeIntervalSince1970
         )
+        // Before trusting: a pairing that cannot name this Mac must leave no
+        // half-paired device behind (#485).
+        let serverId = try await self.serverId()
         try await self.trusted.trust(device)
-        let serverId = await self.serverId()
         let deviceName = session.deviceName
         await self.finish(.paired(deviceName: deviceName))
         self.log.debug("pairing.confirmed")

--- a/Modules/SyncServer/Sources/SyncServer/SyncServer.swift
+++ b/Modules/SyncServer/Sources/SyncServer/SyncServer.swift
@@ -52,7 +52,7 @@ public actor SyncServer {
             trusted: trusted,
             ui: ui,
             serverName: serverName,
-            serverId: { await (try? meta.serverId()) ?? "" }
+            serverId: { try await meta.serverId() }
         )
         self.pairing = pairing
 

--- a/Modules/SyncServer/Tests/SyncServerTests/ManifestBuilderPodcastTests.swift
+++ b/Modules/SyncServer/Tests/SyncServerTests/ManifestBuilderPodcastTests.swift
@@ -85,6 +85,100 @@ struct ManifestBuilderPodcastTests {
         #expect(episode.durationMs == 3_600_000)
     }
 
+    @Test("an episode stored before the hash migration is hashed from its file (#485)")
+    func legacyEpisodeHashedFromFile() async throws {
+        let database = try await Database(location: .inMemory)
+        let tempRoot = self.makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+        let (podcastId, guid) = try await self.seedDownloadedEpisode(
+            database: database,
+            root: tempRoot,
+            bytes: Data("podcast-audio".utf8),
+            storedHash: nil
+        )
+
+        let manifest = try await ManifestBuilder(database: database, downloadRoot: tempRoot).build(
+            profile: .everything(includePodcasts: true),
+            serverId: "srv", serverName: "Mac", generation: 1, generatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        let expected = SHA256.hash(data: Data("podcast-audio".utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        let episode = try #require(manifest.episodes.first)
+        #expect(episode.podcastId == podcastId)
+        #expect(episode.guid == guid)
+        #expect(episode.sha256 == expected)
+    }
+
+    @Test("an episode whose file cannot be read is left out, never advertised under a partial hash (#485)")
+    func unreadableEpisodeOmitted() async throws {
+        let database = try await Database(location: .inMemory)
+        let tempRoot = self.makeTempRoot()
+        let (podcastId, guid) = try await self.seedDownloadedEpisode(
+            database: database,
+            root: tempRoot,
+            bytes: Data("podcast-audio".utf8),
+            storedHash: nil,
+            permissions: 0o000
+        )
+        defer {
+            // Restore read access so the temporary tree can be removed.
+            let fileURL = DownloadStore(root: tempRoot).fileURL(podcastID: podcastId, guid: guid, mime: "audio/mpeg")
+            try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+            try? FileManager.default.removeItem(at: tempRoot)
+        }
+
+        let manifest = try await ManifestBuilder(database: database, downloadRoot: tempRoot).build(
+            profile: .everything(includePodcasts: true),
+            serverId: "srv", serverName: "Mac", generation: 1, generatedAt: Date(timeIntervalSince1970: 0)
+        )
+
+        #expect(manifest.episodes.isEmpty)
+    }
+
+    /// Inserts a show plus one downloaded episode and writes its file.
+    private func seedDownloadedEpisode(
+        database: Database,
+        root: URL,
+        bytes: Data,
+        storedHash: String?,
+        permissions: Int? = nil
+    ) async throws -> (podcastId: Int64, guid: String) {
+        let podcastId = try await PodcastRepository(database: database).insert(Podcast(
+            feedURL: "https://example.test/feed",
+            title: "Some Show",
+            addedAt: 0
+        ))
+        let guid = "https://example.test/some-show/12"
+        _ = try await EpisodeRepository(database: database).upsert(PodcastEpisode(
+            podcastID: podcastId,
+            guid: guid,
+            title: "Episode 12",
+            audioURL: "https://example.test/12.mp3",
+            audioMIME: "audio/mpeg",
+            addedAt: 0
+        ))
+        let fileURL = DownloadStore(root: root).fileURL(podcastID: podcastId, guid: guid, mime: "audio/mpeg")
+        try FileManager.default.createDirectory(
+            at: fileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try bytes.write(to: fileURL)
+        if let permissions {
+            try FileManager.default.setAttributes([.posixPermissions: permissions], ofItemAtPath: fileURL.path)
+        }
+        try await EpisodeStateRepository(database: database).setDownloadState(
+            podcastID: podcastId,
+            guid: guid,
+            state: .downloaded,
+            path: fileURL.path,
+            bytes: Int64(bytes.count),
+            hash: storedHash
+        )
+        return (podcastId, guid)
+    }
+
     @Test("a show with cached artwork advertises its SHA-256; a gone file advertises nil (22-10)")
     func artworkHashAdvertised() async throws {
         let database = try await Database(location: .inMemory)

--- a/Modules/SyncServer/Tests/SyncServerTests/ManifestRoutesTests.swift
+++ b/Modules/SyncServer/Tests/SyncServerTests/ManifestRoutesTests.swift
@@ -67,6 +67,33 @@ struct ManifestRoutesTests {
         #expect(manifest.tracks.count == 1)
     }
 
+    @Test("the ping route answers this Mac's id and generation")
+    func pingAnswersIdentity() async throws {
+        let database = try await Database(location: .inMemory)
+        let response = await self.makeRouter(database).dispatch(self.request("/v1/ping"), context: self.trustedContext())
+
+        #expect(response.status == 200)
+        let json = try #require(try JSONSerialization.jsonObject(with: response.body) as? [String: Any])
+        #expect(json["protocolVersion"] as? Int == 1)
+        #expect((json["serverId"] as? String)?.isEmpty == false)
+        #expect(json["generation"] as? Int == 0)
+    }
+
+    @Test("a ping that cannot read the identity answers 500, not an empty server id (#485)")
+    func pingFailsLoudlyWithoutIdentity() async throws {
+        let database = try await Database(location: .inMemory)
+        // The read fails the way a damaged database would.
+        try await database.write { db in
+            try db.execute(sql: "DROP TABLE sync_meta")
+        }
+
+        let response = await self.makeRouter(database).dispatch(self.request("/v1/ping"), context: self.trustedContext())
+
+        #expect(response.status == 500)
+        let body = String(decoding: response.body, as: UTF8.self)
+        #expect(!body.contains("\"serverId\""), "an empty id reads as a different Mac to the phone")
+    }
+
     @Test("the manifest route rejects an unpaired connection")
     func manifestRejectsUnpaired() async throws {
         let database = try await Database(location: .inMemory)

--- a/Modules/SyncServer/Tests/SyncServerTests/PairingCoordinatorTests.swift
+++ b/Modules/SyncServer/Tests/SyncServerTests/PairingCoordinatorTests.swift
@@ -57,7 +57,10 @@ struct PairingCoordinatorTests {
         let clock: OSAllocatedUnfairLock<Date>
     }
 
-    private func makeHarness(timeout: TimeInterval = 120) async throws -> Harness {
+    private func makeHarness(
+        timeout: TimeInterval = 120,
+        serverId: @escaping @Sendable () async throws -> String = { "server-xyz" }
+    ) async throws -> Harness {
         let identity = try ServerIdentity(store: InMemoryIdentityStore())
         let serverFingerprint = try await identity.fingerprint().hex
         let database = try await Database(location: .inMemory)
@@ -70,7 +73,7 @@ struct PairingCoordinatorTests {
             trusted: trusted,
             ui: ui,
             serverName: { "Test Mac" },
-            serverId: { "server-xyz" },
+            serverId: serverId,
             timeout: timeout,
             now: { clock.withLock { $0 } }
         )
@@ -136,6 +139,23 @@ struct PairingCoordinatorTests {
         #expect(harness.trusted.fingerprints.contains(peer))
         #expect(await harness.coordinator.isPairingMode == false)
         #expect(harness.ui.endedResult == .paired(deviceName: "Pixel"))
+    }
+
+    @Test("pairing fails when this Mac's id cannot be read, rather than pairing under an empty one (#485)")
+    func confirmFailsWithoutServerId() async throws {
+        struct MetaUnavailable: Error {}
+        let harness = try await self.makeHarness(serverId: { throw MetaUnavailable() })
+        let peer = self.peerFingerprint("f")
+        let (response, _) = try await self.armAndStart(harness, peer: peer)
+        let code = try #require(harness.ui.shownCode)
+        let proof = PairingCode.proof(code: code, sessionId: response.sessionId)
+
+        await #expect(throws: MetaUnavailable.self) {
+            _ = try await harness.coordinator.confirm(
+                request: PairConfirm(sessionId: response.sessionId, proof: proof)
+            )
+        }
+        #expect(!harness.trusted.fingerprints.contains(peer), "no half-paired device is left behind")
     }
 
     @Test("three bad proofs lock out the session and revert pairing mode")

--- a/Modules/UI/Sources/UI/Browse/TracksView+Actions.swift
+++ b/Modules/UI/Sources/UI/Browse/TracksView+Actions.swift
@@ -43,7 +43,19 @@ extension TracksView {
             },
             addToPlaylist: { playlistID, tracks in
                 let ids = tracks.compactMap(\.id)
-                Task { try? await lib.playlistService.addTracks(ids, to: playlistID) }
+                Task {
+                    do {
+                        try await lib.playlistService.addTracks(ids, to: playlistID)
+                    } catch {
+                        // The user chose a playlist from the menu; a silent
+                        // failure looks like the tracks were added (#480).
+                        lib.log.error("playlist.addTracks.failed", [
+                            "playlist": playlistID,
+                            "error": String(reflecting: error),
+                        ])
+                        lib.showToast(ToastMessage(text: L10n.string("Couldn’t add those tracks to the playlist.")))
+                    }
+                }
             },
             newPlaylistFromSelection: { tracks in
                 let ids = tracks.compactMap(\.id)

--- a/Modules/UI/Sources/UI/Console/LogConsoleView.swift
+++ b/Modules/UI/Sources/UI/Console/LogConsoleView.swift
@@ -16,6 +16,10 @@ import SwiftUI
 public struct LogConsoleView: View {
     @Bindable var vm: LogConsoleViewModel
 
+    /// Set when Save Log could not write the file, so the failure is not
+    /// silent (#480). Cleared when the alert is dismissed.
+    @State private var exportError: String?
+
     private static let bottomAnchor = "log-console-bottom"
 
     public init(vm: LogConsoleViewModel) {
@@ -35,6 +39,18 @@ public struct LogConsoleView: View {
         }
         .task { self.vm.start() }
         .onDisappear { self.vm.stop() }
+        .alert(L10n.string("Couldn’t save the log"), isPresented: Binding(
+            get: { self.exportError != nil },
+            set: {
+                if !$0 {
+                    self.exportError = nil
+                }
+            }
+        )) {
+            Button(L10n.string("OK")) { self.exportError = nil }
+        } message: {
+            Text(self.exportError ?? "")
+        }
     }
 
     // MARK: - Control bar
@@ -271,7 +287,17 @@ public struct LogConsoleView: View {
             panel.begin { cont.resume(returning: $0) }
         }
         guard outcome == .OK, let url = panel.url else { return }
-        try? text.write(to: url, atomically: true, encoding: .utf8)
+        do {
+            try text.write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            // The user picked a destination and pressed Save; a silent failure
+            // leaves them with no file and no reason (#480).
+            AppLogger.make(.ui).error("log.export.failed", [
+                "file": url.lastPathComponent,
+                "error": String(reflecting: error),
+            ])
+            self.exportError = error.localizedDescription
+        }
     }
 
     // MARK: - Helpers

--- a/Modules/UI/Sources/UI/MetadataEditor/ArtworkEditor.swift
+++ b/Modules/UI/Sources/UI/MetadataEditor/ArtworkEditor.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Library
+import Observability
 import SwiftUI
 import UniformTypeIdentifiers
 
@@ -96,8 +97,16 @@ public struct ArtworkEditor: View {
         ) { result in
             if case let .success(url) = result {
                 SecurityScope.withAccess(url) { scopedURL in
-                    if let data = try? Data(contentsOf: scopedURL) {
-                        self.vm.pendingArtData = Self.normalise(data)
+                    do {
+                        self.vm.pendingArtData = try Self.normalise(Data(contentsOf: scopedURL))
+                    } catch {
+                        // The user picked this file; silence looks like the
+                        // picker did nothing (#480).
+                        AppLogger.make(.ui).error("artwork.read.failed", [
+                            "file": scopedURL.lastPathComponent,
+                            "error": String(reflecting: error),
+                        ])
+                        self.vm.lastError = L10n.string("Couldn’t read that image file.")
                     }
                 }
             }
@@ -123,8 +132,18 @@ public struct ArtworkEditor: View {
                 let url: URL? = await withCheckedContinuation { cont in
                     _ = provider.loadObject(ofClass: URL.self) { url, _ in cont.resume(returning: url) }
                 }
-                guard let url, let data = try? Data(contentsOf: url) else { return }
-                self.vm.pendingArtData = Self.normalise(data)
+                guard let url else { return }
+                do {
+                    self.vm.pendingArtData = try Self.normalise(Data(contentsOf: url))
+                } catch {
+                    // Same for a dropped file: the drop was accepted, so the
+                    // failure has to say something (#480).
+                    AppLogger.make(.ui).error("artwork.drop.failed", [
+                        "file": url.lastPathComponent,
+                        "error": String(reflecting: error),
+                    ])
+                    self.vm.lastError = L10n.string("Couldn’t read that image file.")
+                }
             }
             return true
         }

--- a/Modules/UI/Sources/UI/Resources/Localizable.xcstrings
+++ b/Modules/UI/Sources/UI/Resources/Localizable.xcstrings
@@ -7053,6 +7053,46 @@
         }
       }
     },
+    "Couldn’t add those tracks to the playlist." : {
+      "localizations" : {
+        "en-XA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çóúĺđñ’ţ áđđ ţĥóšé ţŕáçķš ţó ţĥé ƥĺáýĺíšţ. one two three"
+          }
+        }
+      }
+    },
+    "Couldn’t read that image file." : {
+      "localizations" : {
+        "en-XA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çóúĺđñ’ţ ŕéáđ ţĥáţ íḿáĝé ƒíĺé. one two three"
+          }
+        }
+      }
+    },
+    "Couldn’t save the log" : {
+      "localizations" : {
+        "en-XA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çóúĺđñ’ţ šávé ţĥé ĺóĝ one two"
+          }
+        }
+      }
+    },
+    "Couldn’t update Loved for that track." : {
+      "localizations" : {
+        "en-XA" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Çóúĺđñ’ţ úƥđáţé Ĺóvéđ ƒóŕ ţĥáţ ţŕáçķ. one two three"
+          }
+        }
+      }
+    },
     "Country" : {
       "localizations" : {
         "en-XA" : {

--- a/Modules/UI/Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift
+++ b/Modules/UI/Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift
@@ -147,7 +147,14 @@ public final class ScrobbleSettingsViewModel: ObservableObject {
     }
 
     public func disconnectLastFm() async {
-        try? await self.credentials.clearLastFmSession()
+        do {
+            try await self.credentials.clearLastFmSession()
+        } catch {
+            // The credentials are still in the Keychain, so the refresh below
+            // shows the account as connected: say why (#480).
+            self.log.error("scrobble.lastfm.disconnect.failed", ["error": String(reflecting: error)])
+            self.lastFmAuthError = self.message(for: error)
+        }
         await self.refreshConnectionState()
     }
 
@@ -170,7 +177,12 @@ public final class ScrobbleSettingsViewModel: ObservableObject {
     }
 
     public func disconnectListenBrainz() async {
-        try? await self.credentials.clearListenBrainz()
+        do {
+            try await self.credentials.clearListenBrainz()
+        } catch {
+            self.log.error("scrobble.listenbrainz.disconnect.failed", ["error": String(reflecting: error)])
+            self.listenBrainzTokenError = self.message(for: error)
+        }
         await self.refreshConnectionState()
     }
 
@@ -188,7 +200,12 @@ public final class ScrobbleSettingsViewModel: ObservableObject {
     }
 
     public func disconnectRocksky() async {
-        try? await self.credentials.clearRocksky()
+        do {
+            try await self.credentials.clearRocksky()
+        } catch {
+            self.log.error("scrobble.rocksky.disconnect.failed", ["error": String(reflecting: error)])
+            self.rockskyConnectError = self.message(for: error)
+        }
         await self.refreshConnectionState()
     }
 

--- a/Modules/UI/Sources/UI/ViewModels/LibraryViewModel+Rating.swift
+++ b/Modules/UI/Sources/UI/ViewModels/LibraryViewModel+Rating.swift
@@ -41,7 +41,16 @@ public extension LibraryViewModel {
         let newValue = !currentlyLoved
         Task {
             let repo = Persistence.TrackRepository(database: self.database)
-            guard var track = try? await repo.fetch(id: trackID) else { return }
+            var track: Track
+            do {
+                track = try await repo.fetch(id: trackID)
+            } catch {
+                // The user pressed Love; nothing happening with no explanation
+                // is the one outcome this must not have (#480).
+                self.log.error("love.fetch.failed", ["track": trackID, "error": String(reflecting: error)])
+                self.showToast(ToastMessage(text: L10n.string("Couldn’t update Loved for that track.")))
+                return
+            }
             track.loved = newValue
             await self.applyLoved(newValue, to: [track])
         }

--- a/Modules/UI/Sources/UI/ViewModels/LibraryViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/LibraryViewModel.swift
@@ -498,7 +498,14 @@ public final class LibraryViewModel: ObservableObject { // swiftlint:disable:thi
         self.settingsRepo = SettingsRepository(database: database)
         let radioStations = RadioStationRepository(database: database)
         self.radioStations = radioStations
-        self.metadataEditService = try? MetadataEditService(database: database)
+        // A failed init leaves the tag editor unavailable for the whole
+        // session; `self.log` is not usable this early in init (#480).
+        do {
+            self.metadataEditService = try MetadataEditService(database: database)
+        } catch {
+            AppLogger.make(.ui).error("metadataEditService.init_failed", ["error": String(reflecting: error)])
+            self.metadataEditService = nil
+        }
 
         self.fingerprintQueue = Self.makeFingerprintQueue(database: database)
 

--- a/Modules/UI/Tests/UITests/SwallowedErrorUIConventionTests.swift
+++ b/Modules/UI/Tests/UITests/SwallowedErrorUIConventionTests.swift
@@ -1,0 +1,81 @@
+import Foundation
+import Testing
+@testable import UI
+
+// MARK: - SwallowedErrorUIConventionTests
+
+/// #480: the `try?` audit found nine places in this module where a user
+/// action failed and said nothing (`docs/audits/try-optional-audit.md`, class
+/// (c)). Menus, file pickers, drops, alerts and the composition root cannot be
+/// driven host-less, so these pin the fixed shapes in the source: the error is
+/// caught, logged, and put where the person who pressed the button will see it.
+@Suite("Swallowed-error conventions in UI (#480)")
+struct SwallowedErrorUIConventionTests {
+    private func source(_ relativePath: String) throws -> String {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent() // UITests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // Modules/UI/
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("Add to Playlist reports a failure as a toast")
+    func addToPlaylistReportsFailure() throws {
+        let source = try self.source("Sources/UI/Browse/TracksView+Actions.swift")
+        #expect(!source.contains("try? await lib.playlistService.addTracks"))
+        #expect(source.contains("lib.log.error(\"playlist.addTracks.failed\""))
+        #expect(source.contains("L10n.string(\"Couldn’t add those tracks to the playlist.\")"))
+    }
+
+    @Test("the Love toggle reports a failed read as a toast")
+    func loveReportsFailure() throws {
+        let source = try self.source("Sources/UI/ViewModels/LibraryViewModel+Rating.swift")
+        #expect(!source.contains("try? await repo.fetch(id: trackID)"))
+        #expect(source.contains("self.log.error(\"love.fetch.failed\""))
+        #expect(source.contains("L10n.string(\"Couldn’t update Loved for that track.\")"))
+    }
+
+    @Test("Save Log shows why a write failed")
+    func saveLogReportsFailure() throws {
+        let source = try self.source("Sources/UI/Console/LogConsoleView.swift")
+        #expect(!source.contains("try? text.write("))
+        #expect(source.contains("AppLogger.make(.ui).error(\"log.export.failed\""))
+        #expect(source.contains("self.exportError = error.localizedDescription"))
+        #expect(source.contains(".alert(L10n.string(\"Couldn’t save the log\")"))
+    }
+
+    @Test("an unreadable image the user picked or dropped reaches the editor's error alert")
+    func artworkReportsFailure() throws {
+        let source = try self.source("Sources/UI/MetadataEditor/ArtworkEditor.swift")
+        #expect(!source.contains("try? Data(contentsOf:"))
+        #expect(source.contains("AppLogger.make(.ui).error(\"artwork.read.failed\""))
+        #expect(source.contains("AppLogger.make(.ui).error(\"artwork.drop.failed\""))
+        #expect(source.contains("self.vm.lastError = L10n.string(\"Couldn’t read that image file.\")"))
+    }
+
+    @Test("every scrobbler Disconnect reports a Keychain failure in its own field")
+    func disconnectReportsFailure() throws {
+        let source = try self.source("Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift")
+        #expect(!source.contains("try? await self.credentials.clear"))
+        let events = [
+            "scrobble.lastfm.disconnect.failed",
+            "scrobble.listenbrainz.disconnect.failed",
+            "scrobble.rocksky.disconnect.failed",
+        ]
+        for event in events {
+            #expect(source.contains(event), "missing \(event)")
+        }
+        #expect(source.contains("self.lastFmAuthError = self.message(for: error)"))
+        #expect(source.contains("self.listenBrainzTokenError = self.message(for: error)"))
+        #expect(source.contains("self.rockskyConnectError = self.message(for: error)"))
+    }
+
+    @Test("a tag-editor service that cannot start says so in the log")
+    func metadataEditServiceInitLogs() throws {
+        let source = try self.source("Sources/UI/ViewModels/LibraryViewModel.swift")
+        #expect(!source.contains("try? MetadataEditService("))
+        #expect(source.contains("self.metadataEditService = try MetadataEditService(database: database)"))
+        #expect(source.contains("AppLogger.make(.ui).error(\"metadataEditService.init_failed\""))
+    }
+}

--- a/Tests/AppTests/SwallowedErrorAppConventionTests.swift
+++ b/Tests/AppTests/SwallowedErrorAppConventionTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+
+// MARK: - SwallowedErrorAppConventionTests
+
+/// #459: the `try?` audit found App-layer sites that swallowed an error the
+/// user or the log needed (`docs/audits/try-optional-audit.md`, class (c)).
+/// The composition root cannot run host-less, so these pin the fixed shapes
+/// in the source: the error is caught and logged with context, not dropped.
+@Suite("Swallowed-error conventions in App/ (#459)")
+struct SwallowedErrorAppConventionTests {
+    private func source(_ relativePath: String) throws -> String {
+        let url = URL(filePath: #filePath)
+            .deletingLastPathComponent() // AppTests/
+            .deletingLastPathComponent() // Tests/
+            .deletingLastPathComponent() // repo root
+            .appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    @Test("the Subsonic stream cache init failure is logged with its directory, not swallowed (#483)")
+    func streamCacheInitIsLogged() throws {
+        let app = try self.source("App/BocanApp.swift")
+        #expect(!app.contains("try? SubsonicStreamCache("), "a failed init left Subsonic unplayable with no log line")
+        #expect(app.contains("subsonicStreamCache = try SubsonicStreamCache("))
+        #expect(app.contains("log.error(\"subsonic.streamCache.init_failed\""))
+        #expect(app.contains("\"dir\": streamCacheDir.path"))
+    }
+}


### PR DESCRIPTION
Closes #480, #481, #482, #483, #484, #485. Part of #459.

## Summary

The `try?` audit (#490) classified 325 sites; 25 of them carried on as though an operation had succeeded. This is all 25, one commit per module issue, in the order they were filed.

- **App (#483):** the Subsonic stream cache was built with `try?`, so a failed init left streaming dead for the session with nothing logged.
- **Podcasts (#484) and SyncServer (#485):** `while let chunk = try? handle.read(...)` ended on a read error exactly as it does at end of file, so the digest of a partial file was stored as an episode's identity and served to the phone.
- **SyncServer (#485):** `/v1/ping` answered 200 with an empty server id and generation 0 when the identity read failed, which reads to the phone as a different Mac that has never changed; pairing took its id from the same swallowed read and could pair under an empty identity.
- **Playback (#482):** the media-key, lock-screen, Siri and Control Centre handlers wrapped every transport call in `try?`. The in-app buttons surface those errors because their caller catches; these had no caller.
- **Library (#481):** the scan seeded its change detector with a swallowed read (an empty seed means nothing is prunable and every file looks new), the per-file conflict lookup that protects hand-edited tags read a failure as "no such row", and an edit that could not cache the user's cover art still reported success.
- **UI (#480):** nine user actions failed silently, including Add to Playlist, Love, Save Log, a picked or dropped image, and Disconnect for all three scrobblers.

Gates on the final tree: make format, make lint, make build, make test-coverage (95%), make test-ui (1,088), make test-library (394), make test-playback (198), make test-podcasts (164), make test-persistence (332), make test-sync-server (132).

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: One new piece of view state, `exportError` in the log console (`LogConsoleView.swift:20`), which re-renders that window only when a save fails. Everything else reuses an existing surface: `showToast` (`LibraryViewModel.swift:238`), the tag editor's error alert (`TagEditorSheet.swift:85`), the scrobble settings' per-provider error fields, and the player's existing state stream, where a remote failure now yields `.failed` (`QueuePlayer.swift:1735-1741`) and `NowPlayingViewModel` already turns that into a toast. No new observation, no new timer.
2. What is the complexity in terms of library size?
   Answer: Unchanged. No per-row or per-track work is added; each site gains one branch on an error path. The one size-related change is a saving: a scan whose seed read fails now stops (`ScanCoordinator.swift:109-124`) instead of walking every root and re-importing the library.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: Nothing. No task, timer or subscription is created. The scan's abort emits `.finished` as well as `.error` so the progress UI terminates rather than sitting at "scanning" (`ScanCoordinator.swift:115-122`).
4. Which error paths propagate, recover, or fail loudly?
   Answer: This is the change, in three groups. **Propagate:** `linkAlbumArt` throws so a failed art cache fails the edit (`EditTransaction.swift:152`, `:187`); the pairing id read throws before the device is trusted (`PairingCoordinator.swift:191`); the ping answers 500 (`ManifestRoutes.swift:24-31`). **Reach the user:** toasts for Add to Playlist and Love (`TracksView+Actions.swift:52`, `LibraryViewModel+Rating.swift:50`), an alert for Save Log (`LogConsoleView.swift:295`) and for an unreadable image (`ArtworkEditor.swift:105`, `:141`), the provider's own field for each Disconnect (`ScrobbleSettingsViewModel.swift:155`, `:183`, `:206`), and the existing playback toast for remote commands (`QueuePlayer.swift:1714`). **Recover and log,** where recovery is right: the stream cache init (`BocanApp.swift:727-736`), both content hashes returning nil (`DownloadStore.swift:146`, `ManifestBuilder.swift:217`), and the tag-editor service init (`LibraryViewModel.swift:506`).
5. What existing type or utility did you check before adding a new one?
   Answer: Every user-facing failure reuses a surface that already existed rather than inventing one. The issue for #482 assumed the player "already emits a playback error stream"; it does not, so I checked what does exist and used `PlaybackState.failed` on the state stream the strip already watches, rather than adding a channel. The scan's conflict failure mirrors the tag-read failure directly above it (`ScanCoordinator.swift:311-317`), including its `ImportResult.error`. `AudioEngineError` wrapping copies the skip path's own wrapping. The one new type is `PodcastsError.insecureFeedUnsupported`, added in #486, not here. Four new strings go through `L10n` with catalog entries and regenerated en-XA.
6. What did you stub, simplify, or leave incomplete?
   Answer: The 165 class-(b) sites are untouched and now ticketed per module (#491 to #498). Several fixed paths are pinned by source-convention tests rather than executed, because the composition root, a database that fails mid-scan, an unwritable cover-art cache, and AppKit menus and pickers cannot be driven host-less; where a real failure could be driven it is (the scan seed, the remote command, both hashes, the ping, the pairing). The two partial-hash fixes report nothing to the user: the episode is simply left out of the manifest, which the phone sees as an absent file. The scrobble disconnect messages use the existing `message(for:)`, which is not localized, matching the connect path beside them.
7. What is the strongest argument that this is the wrong approach?
   Answer: The line between "tell the user" and "log it" was my judgement when writing the audit, and a reviewer could move several of these across it: the tag-editor service init and the stream cache init are silent losses of a whole feature, yet I only log them, while Save Log gets an alert. The consistent alternative is a single failure surface for the app, which none of these would then need to choose. Second, the pairing fix changes an order of operations, reading the id before trusting the device, which is a behaviour change beyond error reporting; it is deliberate, so a failure leaves no half-paired device, and it is covered by a test. Third, these could have waited for the `logged(...)` helper and the audit script so that all 190 sites moved once; I did not, because the 25 are behaviour bugs and the remaining 165 are not.

**What a user, or another module, would notice is different** (behaviour, not files):
- Add to Playlist, Love, Save Log, choosing or dropping cover art, and Disconnect for Last.fm, ListenBrainz and Rocksky all report a failure now instead of appearing to work.
- Play, skip and seek from the keyboard, headphones, lock screen and Control Centre report a failure the way the in-app buttons do.
- A podcast download or a file offered to the phone is never recorded under the hash of a partly read file; an episode whose file cannot be read is left out of the manifest.
- A phone can no longer pair with, or ping, a Mac that answers with an empty identity.
- A scan that cannot read the library stops and says so, rather than treating the library as empty and re-importing it; a rescan no longer overwrites hand-edited tags when the lookup that protects them fails; an edit that cannot cache the chosen cover art now fails.
- For other code: `FeedFetchResult` and `PodcastsError` are unchanged here (that was #486); `PairingCoordinator`'s `serverId` closure is now throwing; `QueuePlayer.runRemote(_:)` and its `RemoteCommand` are internal API for tests.

**Tried against a full-size library** (thousands of tracks, not a test fixture): no. These are error paths that a healthy library does not take, and the two that could be driven on real data (the scan seed and the conflict lookup) need a database that fails mid-scan. Hand tests, if you want them: pull a USB drive holding a queued track and press the media key, which should now toast rather than do nothing; and rename a downloaded podcast file on disk, then sync, where the episode should be absent from the manifest rather than offered under a wrong hash.

**Things noticed but not fixed here**: the 165 quiet recoveries, filed per module as #491 (UI), #492 (Library), #493 (App), #494 (Playback), #495 (Podcasts), #496 (Scrobble), #497 (AudioEngine), #498 (SyncServer). #497 notes one that may deserve promoting: a corrupt saved equaliser state silently resets the user's bands.
