### PR TITLE
fix(errors): say what went wrong instead of showing a Foundation error code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Song lists from a Subsonic server, in the Songs view, album and artist pages and
 
 When saving tags or cover art fails, the message now says which file failed and why, such as the file being read-only, instead of an error code.
 
+The rest of Bòcan now does the same. Signing in to a scrobbling service, identifying a track, saving a smart playlist, Deep Dive and Phone Sync all name the real reason when something fails, instead of showing an internal code or a fragment of program text.
+
 ## [2.14.1](https://github.com/bocan/bocan-music/compare/v2.14.0...v2.14.1) (2026-09-08)
 
 The now-playing display no longer misses a queue change that lands in the first instants after launch while nothing is playing, which could leave it on "Not playing" until the next track change.

--- a/Modules/Acoustics/Sources/Acoustics/Errors.swift
+++ b/Modules/Acoustics/Sources/Acoustics/Errors.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Errors produced by the Acoustics module.
 public enum AcousticsError: Error, Sendable, Equatable {
     public static func == (lhs: AcousticsError, rhs: AcousticsError) -> Bool {
@@ -27,4 +29,37 @@ public enum AcousticsError: Error, Sendable, Equatable {
     case tagWritebackFailed(underlying: Error)
     /// The supplied URL or path is not valid for the requested operation.
     case invalidInput(reason: String)
+}
+
+// MARK: - AcousticsError + CustomStringConvertible
+
+extension AcousticsError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .fpcalcFailed(exitCode, stderr):
+            "Fingerprinting failed: fpcalc exited with status \(exitCode). \(stderr)"
+        case let .networkError(underlying):
+            "The fingerprint lookup could not reach the service: \(underlying.localizedDescription)"
+        case .rateLimitExceeded:
+            "The fingerprint service is rate limiting requests. Try again shortly."
+        case .noResults:
+            "No matching recording was found for this track."
+        case let .invalidResponse(reason):
+            "The fingerprint service returned data that could not be read: \(reason)"
+        case let .tagWritebackFailed(underlying):
+            "The chosen match could not be written to the file: \(underlying.localizedDescription)"
+        case let .invalidInput(reason):
+            "This item cannot be fingerprinted: \(reason)"
+        }
+    }
+}
+
+// MARK: - AcousticsError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Acoustics.AcousticsError error 3.)" and tells the user nothing (#471).
+extension AcousticsError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
 }

--- a/Modules/Acoustics/Tests/AcousticsTests/ErrorMessageTests.swift
+++ b/Modules/Acoustics/Tests/AcousticsTests/ErrorMessageTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import Acoustics
+
+/// #471: without `LocalizedError`, `localizedDescription` is Foundation's
+/// fallback, which reads "(Acoustics.AcousticsError error 3.)". This enum had
+/// no message text at all before, so the description is new here too.
+@Suite("Acoustics error messages")
+struct ErrorMessageTests {
+    @Test("AcousticsError carries its reason through localizedDescription")
+    func acousticsError() {
+        let cases: [AcousticsError] = [
+            .fpcalcFailed(exitCode: 2, stderr: "no such file"),
+            .rateLimitExceeded,
+            .noResults,
+            .invalidResponse(reason: "not json"),
+            .invalidInput(reason: "file path contains a NUL byte"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+        #expect(AcousticsError.noResults.localizedDescription.contains("No matching recording"))
+    }
+}

--- a/Modules/AudioEngine/Sources/AudioEngine/Errors.swift
+++ b/Modules/AudioEngine/Sources/AudioEngine/Errors.swift
@@ -56,3 +56,13 @@ public enum AudioEngineError: Error, Sendable, CustomStringConvertible {
         }
     }
 }
+
+// MARK: - AudioEngineError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(AudioEngine.AudioEngineError error 3.)" and tells the user nothing (#471).
+extension AudioEngineError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/AudioEngine/Tests/AudioEngineTests/ErrorMessageTests.swift
+++ b/Modules/AudioEngine/Tests/AudioEngineTests/ErrorMessageTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Testing
+@testable import AudioEngine
+
+/// #471: without `LocalizedError`, `localizedDescription` is Foundation's
+/// fallback, which reads "(AudioEngine.AudioEngineError error 3.)".
+@Suite("AudioEngine error messages")
+struct ErrorMessageTests {
+    @Test("AudioEngineError carries its reason through localizedDescription")
+    func audioEngineError() throws {
+        let url = try #require(URL(string: "file:///tmp/track.flac"))
+        let cases: [AudioEngineError] = [
+            .fileNotFound(url),
+            .unsupportedFormat(magic: Data([0x00, 0x01]), url: url),
+            .outputDeviceUnavailable,
+            .seekOutOfRange(requested: 90, duration: 60),
+            .cancelled,
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+        #expect(AudioEngineError.fileNotFound(url).localizedDescription.contains("track.flac"))
+    }
+}

--- a/Modules/Library/Sources/Library/DeepDive/DeepDiveModels.swift
+++ b/Modules/Library/Sources/Library/DeepDive/DeepDiveModels.swift
@@ -162,3 +162,30 @@ public enum DeepDiveError: Error, Sendable, Equatable {
     case rateLimited
     case notFound
 }
+
+// MARK: - DeepDiveError + CustomStringConvertible
+
+extension DeepDiveError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .noIdentifier:
+            "No MusicBrainz match was found for this artist."
+        case .offline:
+            "Deep Dive needs a network connection, and nothing is cached for this artist yet."
+        case .rateLimited:
+            "MusicBrainz is rate limiting requests. Try again shortly."
+        case .notFound:
+            "No Deep Dive information was found for this artist."
+        }
+    }
+}
+
+// MARK: - DeepDiveError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Library.DeepDiveError error 3.)" and tells the user nothing (#471).
+extension DeepDiveError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Library/Sources/Library/Errors.swift
+++ b/Modules/Library/Sources/Library/Errors.swift
@@ -52,3 +52,14 @@ public enum LibraryError: Error, Sendable, CustomStringConvertible {
         }
     }
 }
+
+// MARK: - LibraryError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Library.LibraryError error 3.)" and tells the user nothing. The UI and App
+/// layers show `localizedDescription` in 37 places (#471).
+extension LibraryError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Library/Sources/Library/Playlists/PlaylistError.swift
+++ b/Modules/Library/Sources/Library/Playlists/PlaylistError.swift
@@ -32,3 +32,13 @@ public enum PlaylistError: Error, Sendable, CustomStringConvertible, Equatable {
         }
     }
 }
+
+// MARK: - PlaylistError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Library.PlaylistError error 3.)" and tells the user nothing (#471).
+extension PlaylistError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Library/Sources/Library/SmartPlaylists/SmartPlaylistErrors.swift
+++ b/Modules/Library/Sources/Library/SmartPlaylists/SmartPlaylistErrors.swift
@@ -34,3 +34,44 @@ public enum SmartPlaylistError: Error, Sendable {
     /// removes the broken row.
     case invalidRule(reason: String)
 }
+
+// MARK: - SmartPlaylistError + CustomStringConvertible
+
+extension SmartPlaylistError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .emptyGroup:
+            "A rule group has no rules in it."
+        case .betweenRangeReversed:
+            "A 'between' rule has its range the wrong way round."
+        case let .invalidRegex(pattern):
+            "'\(pattern)' is not a valid regular expression."
+        case let .incompatibleComparator(field, comparator):
+            "The condition '\(comparator.rawValue)' cannot be used with \(field.rawValue)."
+        case let .incompatibleValue(field, _):
+            "The value given for \(field.rawValue) is the wrong type for that field."
+        case let .notFound(id):
+            "Smart playlist \(id) was not found."
+        case let .notSmartPlaylist(id):
+            "Playlist \(id) is not a smart playlist."
+        case let .decodeFailed(reason):
+            "The saved rules could not be read: \(reason)"
+        case let .tooDeeplyNested(maxDepth):
+            "Rule groups are nested too deeply. The limit is \(maxDepth) levels."
+        case let .cannotReferenceSmartPlaylist(id):
+            "A rule cannot refer to smart playlist \(id). Only manual playlists can be used."
+        case let .invalidRule(reason):
+            "This playlist has a rule this version does not recognise: \(reason)"
+        }
+    }
+}
+
+// MARK: - SmartPlaylistError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Library.SmartPlaylistError error 3.)" and tells the user nothing (#471).
+extension SmartPlaylistError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Library/Tests/LibraryTests/ErrorMessageTests.swift
+++ b/Modules/Library/Tests/LibraryTests/ErrorMessageTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import Testing
+@testable import Library
+
+/// #471: a plain `Error` enum's `localizedDescription` is Foundation's fallback,
+/// which reads "(Library.EditError error 3.)". The UI and App layers show
+/// `localizedDescription` in 37 places, so every module error enum must carry
+/// its reason through it. Four of them live in this module.
+@Suite("Library error messages")
+struct ErrorMessageTests {
+    /// The defect this issue exists to remove: a Foundation error code where a
+    /// reason should be.
+    private func expectNoErrorCode(_ message: String, _ label: String) {
+        #expect(
+            message.range(of: #"error \d"#, options: .regularExpression) == nil,
+            "\(label) still shows a Foundation error code: \(message)"
+        )
+    }
+
+    @Test("LibraryError carries its reason through localizedDescription")
+    func libraryError() {
+        let cases: [LibraryError] = [
+            .invalidPath("/nope"),
+            .scanAlreadyInProgress,
+            .databaseUnavailable("locked"),
+            .listenExportUnreadable(reason: "truncated"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            self.expectNoErrorCode(error.localizedDescription, "LibraryError")
+        }
+        #expect(LibraryError.invalidPath("/nope").localizedDescription.contains("/nope"))
+    }
+
+    @Test("PlaylistError carries its reason through localizedDescription")
+    func playlistError() {
+        let cases: [PlaylistError] = [
+            .notFound(7),
+            .emptyName,
+            .invalidAccentColor("nope"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            self.expectNoErrorCode(error.localizedDescription, "PlaylistError")
+        }
+        #expect(PlaylistError.notFound(7).localizedDescription.contains("7"))
+    }
+
+    @Test("SmartPlaylistError names the broken rule rather than a code")
+    func smartPlaylistError() {
+        let cases: [SmartPlaylistError] = [
+            .emptyGroup,
+            .betweenRangeReversed,
+            .invalidRegex("["),
+            .incompatibleComparator(field: .title, comparator: .greaterThan),
+            .incompatibleValue(field: .title, value: .int(3)),
+            .notFound(9),
+            .notSmartPlaylist(9),
+            .decodeFailed("bad json"),
+            .tooDeeplyNested(maxDepth: 3),
+            .cannotReferenceSmartPlaylist(id: 4),
+            .invalidRule(reason: "unknown field"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            self.expectNoErrorCode(error.localizedDescription, "SmartPlaylistError")
+        }
+
+        // The field and comparator are named, not dumped as Swift case values.
+        let mismatch = SmartPlaylistError.incompatibleComparator(field: .title, comparator: .greaterThan)
+        #expect(mismatch.localizedDescription.contains(Field.title.rawValue))
+        #expect(mismatch.localizedDescription.contains(Comparator.greaterThan.rawValue))
+    }
+
+    @Test("DeepDiveError carries its reason through localizedDescription")
+    func deepDiveError() {
+        let cases: [DeepDiveError] = [.noIdentifier, .offline, .rateLimited, .notFound]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            self.expectNoErrorCode(error.localizedDescription, "DeepDiveError")
+        }
+    }
+}

--- a/Modules/Persistence/Sources/Persistence/Errors.swift
+++ b/Modules/Persistence/Sources/Persistence/Errors.swift
@@ -51,3 +51,13 @@ public enum PersistenceError: Error, Sendable, CustomStringConvertible {
         }
     }
 }
+
+// MARK: - PersistenceError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Persistence.PersistenceError error 3.)" and tells the user nothing (#471).
+extension PersistenceError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Persistence/Tests/PersistenceTests/ErrorMessageTests.swift
+++ b/Modules/Persistence/Tests/PersistenceTests/ErrorMessageTests.swift
@@ -1,0 +1,27 @@
+import Foundation
+import Testing
+@testable import Persistence
+
+/// #471: without `LocalizedError`, `localizedDescription` is Foundation's
+/// fallback, which reads "(Persistence.PersistenceError error 3.)".
+@Suite("Persistence error messages")
+struct ErrorMessageTests {
+    @Test("PersistenceError carries its reason through localizedDescription")
+    func persistenceError() {
+        let cases: [PersistenceError] = [
+            .integrityCheckFailed(details: "page 4"),
+            .notFound(entity: "Track", id: 12),
+            .uniqueConstraintViolation(table: "tracks", column: "file_url"),
+            .bookmarkResolutionFailed(reason: "stale"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+        #expect(PersistenceError.notFound(entity: "Track", id: 12).localizedDescription.contains("Track"))
+    }
+}

--- a/Modules/Playback/Sources/Playback/Errors.swift
+++ b/Modules/Playback/Sources/Playback/Errors.swift
@@ -26,3 +26,13 @@ public enum PlaybackError: Error, Sendable, CustomStringConvertible {
         }
     }
 }
+
+// MARK: - PlaybackError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(Playback.PlaybackError error 3.)" and tells the user nothing (#471).
+extension PlaybackError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Playback/Tests/PlaybackTests/ErrorMessageTests.swift
+++ b/Modules/Playback/Tests/PlaybackTests/ErrorMessageTests.swift
@@ -1,0 +1,28 @@
+import Foundation
+import Testing
+@testable import Playback
+
+/// #471: without `LocalizedError`, `localizedDescription` is Foundation's
+/// fallback, which reads "(Playback.PlaybackError error 3.)". The UI shows
+/// `localizedDescription`, so the reason has to survive it.
+@Suite("Playback error messages")
+struct ErrorMessageTests {
+    @Test("PlaybackError carries its reason through localizedDescription")
+    func playbackError() {
+        let cases: [PlaybackError] = [
+            .noBookmark(trackID: 12),
+            .trackNotFound(id: 12),
+            .queueEmpty,
+            .incompatibleFormat(reason: "sample rate"),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+        #expect(PlaybackError.queueEmpty.localizedDescription.contains("queue is empty"))
+    }
+}

--- a/Modules/Scrobble/Sources/Scrobble/Errors.swift
+++ b/Modules/Scrobble/Sources/Scrobble/Errors.swift
@@ -25,3 +25,43 @@ public enum ScrobbleError: Error, Sendable, Equatable {
     /// User cancelled the auth flow.
     case authCancelled
 }
+
+// MARK: - ScrobbleError + CustomStringConvertible
+
+extension ScrobbleError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .notAuthenticated(provider):
+            "\(provider): not signed in."
+        case let .invalidCredentials(provider):
+            "\(provider) rejected the saved credentials. Sign in again."
+        case let .transient(provider, reason, _):
+            "\(provider) is temporarily unavailable: \(reason). It will be retried."
+        case let .permanent(provider, reason):
+            "\(provider) rejected this play: \(reason)"
+        case .offline:
+            "No network connection. Plays are queued until it returns."
+        case .timestampOutOfRange:
+            "This play is too far in the past to submit."
+        case let .keychain(status, message):
+            "Keychain access failed: \(message) (status \(status))"
+        case let .malformedResponse(provider, reason):
+            "\(provider) returned an unexpected response: \(reason)"
+        case .authTimeout:
+            "The sign-in window closed before it was authorised."
+        case .authCancelled:
+            "Sign-in was cancelled."
+        }
+    }
+}
+
+// MARK: - ScrobbleError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback. The Settings
+/// panes put this straight into their error fields, so before #471 a failed
+/// sign-in showed a raw case dump such as `notAuthenticated(provider: "lastfm")`.
+extension ScrobbleError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/Scrobble/Tests/ScrobbleTests/ErrorMessageTests.swift
+++ b/Modules/Scrobble/Tests/ScrobbleTests/ErrorMessageTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import Scrobble
+
+/// #471: the Settings panes put this straight into their error fields, so
+/// before the fix a failed sign-in showed a raw Swift case dump such as
+/// `notAuthenticated(provider: "lastfm")`. This enum had no message text at
+/// all, so the description is new here too.
+@Suite("Scrobble error messages")
+struct ErrorMessageTests {
+    @Test("ScrobbleError carries its reason through localizedDescription")
+    func scrobbleError() {
+        let cases: [ScrobbleError] = [
+            .notAuthenticated(provider: "Last.fm"),
+            .invalidCredentials(provider: "Last.fm"),
+            .transient(provider: "ListenBrainz", reason: "rate limited", retryAfter: 60),
+            .permanent(provider: "Rocksky", reason: "rejected"),
+            .offline,
+            .timestampOutOfRange,
+            .keychain(status: -25300, message: "read failed"),
+            .malformedResponse(provider: "Last.fm", reason: "no body"),
+            .authTimeout,
+            .authCancelled,
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+
+        // The provider is named, and no Swift case dump survives.
+        let notSignedIn = ScrobbleError.notAuthenticated(provider: "Last.fm")
+        #expect(notSignedIn.localizedDescription.contains("Last.fm"))
+        #expect(!notSignedIn.localizedDescription.contains("notAuthenticated"))
+    }
+}

--- a/Modules/SyncServer/Sources/SyncServer/SyncServerError.swift
+++ b/Modules/SyncServer/Sources/SyncServer/SyncServerError.swift
@@ -17,3 +17,34 @@ public enum SyncServerError: Error, Sendable {
     /// stored file URL was unparsable and no bookmark exists (ADR-088).
     case transcodeSourceUnavailable(trackID: Int64)
 }
+
+// MARK: - SyncServerError + CustomStringConvertible
+
+/// `reason` is a short non-sensitive token by the contract on the cases above,
+/// so it is safe to show. Nothing here widens that: no code, nonce or proof.
+extension SyncServerError: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case let .pairing(reason):
+            "Pairing failed: \(reason)"
+        case let .identity(reason, status):
+            if let status {
+                "The sync server's identity could not be prepared: \(reason) (status \(status))"
+            } else {
+                "The sync server's identity could not be prepared: \(reason)"
+            }
+        case let .transcodeSourceUnavailable(trackID):
+            "The source file for track \(trackID) could not be found."
+        }
+    }
+}
+
+// MARK: - SyncServerError + LocalizedError
+
+/// Without this, `localizedDescription` is Foundation's fallback, which reads
+/// "(SyncServer.SyncServerError error 3.)" and tells the user nothing (#471).
+extension SyncServerError: LocalizedError {
+    public var errorDescription: String? {
+        self.description
+    }
+}

--- a/Modules/SyncServer/Tests/SyncServerTests/ErrorMessageTests.swift
+++ b/Modules/SyncServer/Tests/SyncServerTests/ErrorMessageTests.swift
@@ -1,0 +1,31 @@
+import Foundation
+import Testing
+@testable import SyncServer
+
+/// #471: without `LocalizedError`, `localizedDescription` is Foundation's
+/// fallback, which reads "(SyncServer.SyncServerError error 3.)". This enum had
+/// no message text at all, so the description is new here too.
+@Suite("SyncServer error messages")
+struct ErrorMessageTests {
+    @Test("SyncServerError carries its reason through localizedDescription")
+    func syncServerError() {
+        let cases: [SyncServerError] = [
+            .pairing(reason: "codeMismatch"),
+            .identity(reason: "keychainUnavailable", status: -25300),
+            .identity(reason: "inMemoryHasNoSecIdentity", status: nil),
+            .transcodeSourceUnavailable(trackID: 42),
+        ]
+        for error in cases {
+            #expect(error.errorDescription == error.description)
+            #expect(error.localizedDescription == error.description)
+            #expect(
+                error.localizedDescription.range(of: #"error \d"#, options: .regularExpression) == nil,
+                "still shows a Foundation error code: \(error.localizedDescription)"
+            )
+        }
+
+        // The status is included when there is one and omitted when there is not.
+        #expect(SyncServerError.identity(reason: "x", status: -25300).localizedDescription.contains("-25300"))
+        #expect(!SyncServerError.identity(reason: "x", status: nil).localizedDescription.contains("status"))
+    }
+}

--- a/Modules/UI/Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift
+++ b/Modules/UI/Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift
@@ -232,10 +232,11 @@ public final class ScrobbleSettingsViewModel: ObservableObject {
         }
     }
 
+    /// `ScrobbleError` conforms to `LocalizedError` (#471), so its reason now
+    /// survives `localizedDescription`. The old special case stringified the
+    /// enum instead, which put a raw case dump such as
+    /// `notAuthenticated(provider: "lastfm")` into the Settings error field.
     private func message(for error: Error) -> String {
-        if let scrobbleError = error as? ScrobbleError {
-            return String(describing: scrobbleError)
-        }
-        return error.localizedDescription
+        error.localizedDescription
     }
 }


### PR DESCRIPTION
Closes #471.

A plain Swift error enum's `localizedDescription` is Foundation's fallback, which reads like "(Library.EditError error 3.)". The UI and App layers show `localizedDescription` in 37 places, so any module error reaching one of them told the user nothing. #469 fixed the first two enums; this fixes the rest.

### The issue's list was stale by two

It named twelve. `PodcastsError` already conformed inline, and `SubsonicError` already had a complete `LocalizedError` extension with a message per case. So ten, in two shapes:

| Shape | Enums | Work |
|---|---|---|
| Already had a `description` | `LibraryError`, `PlaybackError`, `PersistenceError`, `AudioEngineError`, `PlaylistError` | Return it through `errorDescription` |
| No message text at all | `AcousticsError`, `ScrobbleError`, `SmartPlaylistError`, `DeepDiveError`, `SyncServerError` | A message written per case |

### One live defect found on the way

The scrobble settings pane special-cased `ScrobbleError` and stringified it, so a failed sign-in put a raw Swift case dump such as `notAuthenticated(provider: "lastfm")` straight into the Settings error field a user reads. Conforming the enum made that branch redundant, and it is gone.

`SyncServerError` documents that its `reason` is a short non-sensitive token, never a code, nonce or proof. Its new messages show the reason and the status where there is one, and widen nothing.

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: None. No observation, timer or view identity changed. The ten conformances are additive extensions carrying no stored state, evaluated only when something formats an error. The single behavioural site, `Modules/UI/Sources/UI/Scrobble/ScrobbleSettingsViewModel.swift:235`, assigns the same three published error fields at the same moments, with better text.
2. What is the complexity in terms of library size?
   Answer: Unchanged, and independent of library size. Every added path is a switch over a fixed-case enum, run once per error formatted. Nothing iterates tracks, albums or files.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: Nothing. No task, observation, timer or resource is created.
4. Which error paths propagate, recover, or fail loudly?
   Answer: No error path changed shape; nothing new is thrown, caught or swallowed. What changed is the text `localizedDescription` yields for ten types. One consequence worth stating: `String(reflecting:)` falls back to `CustomStringConvertible`, so the five enums that gained a `description` also change the wording of existing `log.warning(..., String(reflecting: error))` lines in their modules. That is more readable, and no test asserted on the old reflected form, which I checked before changing anything.
5. What existing type or utility did you check before adding a new one?
   Answer: Every module error enum's current conformance, which is how the stale list surfaced. Reused the appended-extension shape `SubsonicError` already uses rather than inventing a second one, and reused each enum's existing `description` where it had one. No new type. The tests follow `Modules/Podcasts/Tests/PodcastsTests/PodcastsErrorTests.swift`, the existing precedent.
6. What did you stub, simplify, or leave incomplete?
   Answer: `SmartPlaylistError.incompatibleValue` names the field and says the value is the wrong type without rendering the `Value` payload, which would need a display form for a ten-case indirect enum that nothing else wants. Messages are English at the module layer, per the #469 decision, so they are not localized. Tests cover representative cases per enum rather than every case.
7. What is the strongest argument that this is the wrong approach?
   Answer: It ships module-owned English into user-facing dialogs, where the localization rule prefers a UI-side mapping. Against that: 37 sites already show raw `localizedDescription`; the alternative is a far larger change touching every one of them; and these strings interpolate file names, provider names and reasons that cannot be pre-localized. If full localization is wanted later, explicit and tested English is a better starting point than Foundation's error codes.

**What a user, or another module, would notice is different** (behaviour, not files):
- Any of these failures now reads as a reason rather than "(Module.XError error N.)".
- A failed scrobbler sign-in no longer shows a Swift case dump in Settings.
- Log lines in five modules that reflected these errors now carry the readable message instead.
- Other modules: ten error types now conform to `LocalizedError`, so anything catching them as a bare `Error` gets a usable message for free.

**Tried against a full-size library** (thousands of tracks, not a test fixture): not relevant to this change. Nothing here touches the library, reads the database, or scales with track count; the code runs only when an error is formatted.

**Things noticed but not fixed here**: none new. The two open findings from #469 remain #472 and #511.

### Tests

Seven files rather than ten, because a module's tests only see its own module and four of these enums live in `Library`. Each asserts `errorDescription` matches `description` and that no message contains a Foundation error code, matched by regex. The `Library` one also proves the smart-playlist message names the field and comparator rather than dumping Swift case values.

Gates: format, strict lint, the eight affected module suites at 2,514 tests, build, and coverage at 95%.
