### PR TITLE
fix(ui): give the Subsonic song tables an owner for their rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Adding a podcast whose directory listing gives a plain-http feed address now wor
 
 The main window and the Songs list no longer redraw every time a synced lyric line changes, a lyrics fetch starts or finishes, or the sync offset moves. Only the lyrics pane updates on those moments, so playing a song with synced lyrics while the full Songs list is open stays smooth.
 
-Song lists from a Subsonic server, in the Songs view, album and artist pages and search results, no longer re-check every row whenever something else in the window updates, such as a synced lyric line changing. Large remote albums and playlists stay smooth.
+Song lists from a Subsonic server, in the Songs view, album and artist pages and search results, no longer rebuild themselves whenever something else in the window updates, such as a synced lyric line changing. Large remote albums and playlists stay smooth. A star or rating you set on one of those songs now shows in the list straight away, instead of waiting for the next time something else redraws the window.
 
 When saving tags or cover art fails, the message now says which file failed and why, such as the file being read-only, instead of an error code.
 

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicAlbumDetailView.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicAlbumDetailView.swift
@@ -7,28 +7,81 @@ import SwiftUI
 
 /// Loads a single Subsonic album via `getAlbum` and exposes its songs.
 @MainActor
-public final class SubsonicAlbumDetailViewModel: ObservableObject {
+public final class SubsonicAlbumDetailViewModel: ObservableObject, SubsonicAnnotationObserving {
     public let serverID: UUID
     public let albumID: String
 
     @Published public private(set) var album: AlbumID3? {
-        didSet { self.albumVersion &+= 1 }
+        didSet { self.rebuildRows() }
     }
 
-    /// Moves on every write to `album`, whose songs feed the table;
-    /// `SubsonicSongTable` skips its per-row walks while the rows version it
-    /// is given holds (#455).
-    public private(set) var albumVersion = 0
+    /// The album's songs, in the order the server returned them.
+    public var songs: [Song] {
+        self.album?.song ?? []
+    }
+
+    /// Decorated rows for `SubsonicSongTable`, owned here rather than mapped
+    /// in the view's body, so the O(n) decoration runs once per change of the
+    /// album, the annotation overrides or the server name instead of once per
+    /// re-render (#475).
+    @Published private(set) var rows: [SubsonicSongTableRow] = [] {
+        didSet { self.rowsVersion &+= 1 }
+    }
+
+    /// Moves on every write to `rows` via `didSet`, so no path can forget it;
+    /// `SubsonicSongTable` skips its per-row walks while it holds (#455).
+    private(set) var rowsVersion = 0
+
+    /// Display name of this server, carried on every row. Set by the view,
+    /// which reads it from the sidebar server list; a rename rebuilds the rows.
+    public var serverName: String {
+        didSet {
+            guard self.serverName != oldValue else { return }
+            self.rebuildRows()
+        }
+    }
+
     @Published public private(set) var isLoading = false
     @Published public var errorMessage: String?
 
     private let dataSource: any SubsonicBrowseDataSource
+    /// Held strongly: the coordinator outlives this view model, and its own
+    /// reference back to here is weak.
+    private let annotations: SubsonicAnnotationCoordinator?
     private let log = AppLogger.make(.ui)
 
-    public init(serverID: UUID, albumID: String, dataSource: any SubsonicBrowseDataSource) {
+    public init(
+        serverID: UUID,
+        albumID: String,
+        dataSource: any SubsonicBrowseDataSource,
+        annotations: SubsonicAnnotationCoordinator? = nil,
+        serverName: String = ""
+    ) {
         self.serverID = serverID
         self.albumID = albumID
         self.dataSource = dataSource
+        self.annotations = annotations
+        self.serverName = serverName
+        annotations?.addObserver(self)
+    }
+
+    // MARK: - Rows
+
+    /// Rebuilds every row from the album's songs and the current overrides.
+    private func rebuildRows() {
+        let serverID = self.serverID
+        let serverName = self.serverName
+        let annotations = self.annotations
+        self.rows = self.songs.map {
+            SubsonicSongTableRow.make(
+                song: $0, serverID: serverID, serverName: serverName, annotations: annotations
+            )
+        }
+    }
+
+    /// A star or rating moved: the stored rows are now stale (#475).
+    public func annotationOverridesDidChange() {
+        self.rebuildRows()
     }
 
     public func load() async {
@@ -75,7 +128,11 @@ public struct SubsonicAlbumDetailView: View {
         self.coverArtProvider = coverArtProvider
         self._vm = StateObject(
             wrappedValue: SubsonicAlbumDetailViewModel(
-                serverID: serverID, albumID: albumID, dataSource: dataSource
+                serverID: serverID,
+                albumID: albumID,
+                dataSource: dataSource,
+                annotations: library.subsonicAnnotations,
+                serverName: library.subsonicServers.first { $0.id == serverID }?.name ?? ""
             )
         )
     }
@@ -99,6 +156,11 @@ public struct SubsonicAlbumDetailView: View {
             if self.vm.album == nil {
                 await self.vm.load()
             }
+        }
+        // The row owner needs the server's display name, and the sidebar list
+        // it comes from may load, or be renamed, after this view appears.
+        .onChange(of: self.currentServerName, initial: true) { _, name in
+            self.vm.serverName = name
         }
         .loadErrorAlert(L10n.string("Couldn't load album"), message: self.$vm.errorMessage)
     }
@@ -128,10 +190,8 @@ public struct SubsonicAlbumDetailView: View {
 
     private func songsTable(_ songs: [Song]) -> some View {
         SubsonicSongTable(
-            rows: self.makeRows(songs),
-            rowsVersion: SubsonicSongTable.rowsVersion(
-                songs: self.vm.albumVersion, annotations: self.annotationCoordinator
-            ),
+            rows: self.vm.rows,
+            rowsVersion: self.vm.rowsVersion,
             isLoading: false,
             hasMorePages: false,
             coverArtProvider: self.coverArtProvider,
@@ -148,25 +208,6 @@ public struct SubsonicAlbumDetailView: View {
         guard let serverID = np.nowPlayingSubsonicServerID,
               let songID = np.nowPlayingSubsonicSongID else { return nil }
         return SubsonicSongTableRow.id(serverID: serverID, songID: songID)
-    }
-
-    private func makeRows(_ songs: [Song]) -> [SubsonicSongTableRow] {
-        let serverName = self.currentServerName
-        return songs.map { song in
-            SubsonicSongTableRow(
-                song: song,
-                serverID: self.serverID,
-                serverName: serverName,
-                starred: self.annotationCoordinator?.isStarred(
-                    songID: song.id,
-                    serverStarred: song.starred
-                ) ?? (song.starred != nil),
-                rating: self.annotationCoordinator?.rating(
-                    songID: song.id,
-                    serverRating: song.userRating
-                ) ?? (song.userRating ?? 0)
-            )
-        }
     }
 
     private func makeActions(_ songs: [Song]) -> SubsonicSongTableActions {

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicAnnotationCoordinator.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicAnnotationCoordinator.swift
@@ -3,6 +3,21 @@ import Observability
 import SwiftSonic
 import SwiftUI
 
+// MARK: - SubsonicAnnotationObserving
+
+/// A view model that owns a stored `SubsonicSongTableRow` array derived from
+/// the coordinator's overrides, and rebuilds it when one of them moves.
+///
+/// The coordinator reaches its observers directly because nothing else would:
+/// it is handed to the browse views through the SwiftUI environment, which
+/// does not subscribe to `objectWillChange`, so a star or rating change on its
+/// own re-renders no view (#475).
+@MainActor
+public protocol SubsonicAnnotationObserving: AnyObject {
+    /// Called after any write to the star or rating overrides.
+    func annotationOverridesDidChange()
+}
+
 // MARK: - SubsonicAnnotationCoordinator
 
 /// Owns the optimistic UI state for star and rating actions on Subsonic
@@ -17,19 +32,38 @@ public final class SubsonicAnnotationCoordinator: ObservableObject {
     /// Per-song optimistic starred override. `true` ⇒ starred,
     /// `false` ⇒ unstarred. Absence means "fall back to server value".
     @Published public private(set) var starOverrides: [String: Bool] = [:] {
-        didSet { self.overridesVersion &+= 1 }
+        didSet { self.notifyObservers() }
     }
 
     /// Per-song optimistic rating override (0–5). Absence means
     /// "fall back to server value".
     @Published public private(set) var ratingOverrides: [String: Int] = [:] {
-        didSet { self.overridesVersion &+= 1 }
+        didSet { self.notifyObservers() }
     }
 
-    /// Moves on every write to either override map. The views that derive
-    /// `SubsonicSongTable` rows from a song list plus these overrides fold it
-    /// into the rows version they hand the table (#455).
-    public private(set) var overridesVersion = 0
+    // MARK: - Row observers
+
+    /// Weakly-held box, so a destination's view model deregisters itself by
+    /// going away with its view and no teardown call is needed.
+    private struct WeakObserver {
+        weak var value: (any SubsonicAnnotationObserving)?
+    }
+
+    private var observers: [WeakObserver] = []
+
+    /// Registers a row-owning view model for override changes (#475).
+    /// Registering the same object twice is a no-op.
+    public func addObserver(_ observer: any SubsonicAnnotationObserving) {
+        self.observers.removeAll { $0.value == nil || $0.value === observer }
+        self.observers.append(WeakObserver(value: observer))
+    }
+
+    private func notifyObservers() {
+        self.observers.removeAll { $0.value == nil }
+        for box in self.observers {
+            box.value?.annotationOverridesDidChange()
+        }
+    }
 
     // MARK: - Internals
 

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicArtistDetailView.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicArtistDetailView.swift
@@ -10,30 +10,79 @@ import SwiftUI
 /// single list. Albums are available immediately; tracks land as each
 /// `getAlbum` resolves.
 @MainActor
-public final class SubsonicArtistDetailViewModel: ObservableObject {
+public final class SubsonicArtistDetailViewModel: ObservableObject, SubsonicAnnotationObserving {
     public let serverID: UUID
     public let artistID: String
 
     @Published public private(set) var artist: ArtistID3?
     @Published public private(set) var albums: [AlbumID3] = []
     @Published public private(set) var tracks: [Song] = [] {
-        didSet { self.tracksVersion &+= 1 }
+        didSet { self.rebuildRows() }
     }
 
-    /// Moves on every write to `tracks`; `SubsonicSongTable` skips its per-row
-    /// walks while the rows version it is given holds (#455).
-    public private(set) var tracksVersion = 0
+    /// Decorated rows for `SubsonicSongTable`, owned here rather than mapped
+    /// in the view's body, so the O(n) decoration runs once per change of the
+    /// track list, the annotation overrides or the server name instead of once
+    /// per re-render (#475).
+    @Published private(set) var rows: [SubsonicSongTableRow] = [] {
+        didSet { self.rowsVersion &+= 1 }
+    }
+
+    /// Moves on every write to `rows` via `didSet`, so no path can forget it;
+    /// `SubsonicSongTable` skips its per-row walks while it holds (#455).
+    private(set) var rowsVersion = 0
+
+    /// Display name of this server, carried on every row. Set by the view,
+    /// which reads it from the sidebar server list; a rename rebuilds the rows.
+    public var serverName: String {
+        didSet {
+            guard self.serverName != oldValue else { return }
+            self.rebuildRows()
+        }
+    }
+
     @Published public private(set) var isLoading = false
     @Published public private(set) var isLoadingTracks = false
     @Published public var errorMessage: String?
 
     private let dataSource: any SubsonicBrowseDataSource
+    /// Held strongly: the coordinator outlives this view model, and its own
+    /// reference back to here is weak.
+    private let annotations: SubsonicAnnotationCoordinator?
     private let log = AppLogger.make(.ui)
 
-    public init(serverID: UUID, artistID: String, dataSource: any SubsonicBrowseDataSource) {
+    public init(
+        serverID: UUID,
+        artistID: String,
+        dataSource: any SubsonicBrowseDataSource,
+        annotations: SubsonicAnnotationCoordinator? = nil,
+        serverName: String = ""
+    ) {
         self.serverID = serverID
         self.artistID = artistID
         self.dataSource = dataSource
+        self.annotations = annotations
+        self.serverName = serverName
+        annotations?.addObserver(self)
+    }
+
+    // MARK: - Rows
+
+    /// Rebuilds every row from the current tracks and overrides.
+    private func rebuildRows() {
+        let serverID = self.serverID
+        let serverName = self.serverName
+        let annotations = self.annotations
+        self.rows = self.tracks.map {
+            SubsonicSongTableRow.make(
+                song: $0, serverID: serverID, serverName: serverName, annotations: annotations
+            )
+        }
+    }
+
+    /// A star or rating moved: the stored rows are now stale (#475).
+    public func annotationOverridesDidChange() {
+        self.rebuildRows()
     }
 
     public func load() async {
@@ -133,7 +182,11 @@ public struct SubsonicArtistDetailView: View {
         self.coverArtProvider = coverArtProvider
         self._vm = StateObject(
             wrappedValue: SubsonicArtistDetailViewModel(
-                serverID: serverID, artistID: artistID, dataSource: dataSource
+                serverID: serverID,
+                artistID: artistID,
+                dataSource: dataSource,
+                annotations: library.subsonicAnnotations,
+                serverName: library.subsonicServers.first { $0.id == serverID }?.name ?? ""
             )
         )
     }
@@ -161,6 +214,11 @@ public struct SubsonicArtistDetailView: View {
             if self.vm.artist == nil {
                 await self.vm.load()
             }
+        }
+        // The row owner needs the server's display name, and the sidebar list
+        // it comes from may load, or be renamed, after this view appears.
+        .onChange(of: self.currentServerName, initial: true) { _, name in
+            self.vm.serverName = name
         }
         .loadErrorAlert(L10n.string("Couldn't load artist"), message: self.$vm.errorMessage)
     }
@@ -308,27 +366,9 @@ public struct SubsonicArtistDetailView: View {
     @ViewBuilder
     private var songsTable: some View {
         let songs = self.vm.tracks
-        let serverName = self.currentServerName
-        let rows = songs.map { song in
-            SubsonicSongTableRow(
-                song: song,
-                serverID: self.serverID,
-                serverName: serverName,
-                starred: self.annotationCoordinator?.isStarred(
-                    songID: song.id,
-                    serverStarred: song.starred
-                ) ?? (song.starred != nil),
-                rating: self.annotationCoordinator?.rating(
-                    songID: song.id,
-                    serverRating: song.userRating
-                ) ?? (song.userRating ?? 0)
-            )
-        }
         SubsonicSongTable(
-            rows: rows,
-            rowsVersion: SubsonicSongTable.rowsVersion(
-                songs: self.vm.tracksVersion, annotations: self.annotationCoordinator
-            ),
+            rows: self.vm.rows,
+            rowsVersion: self.vm.rowsVersion,
             isLoading: self.vm.isLoadingTracks,
             hasMorePages: false,
             coverArtProvider: self.coverArtProvider,

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicMultiSourceSearchViewModel.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicMultiSourceSearchViewModel.swift
@@ -49,7 +49,7 @@ public struct SubsonicArtistHit: Identifiable, Sendable {
 /// Subsonic views (Songs / Albums / Artists) consume these lists through
 /// their existing native layouts whenever the global search field has text.
 @MainActor
-public final class SubsonicMultiSourceSearchViewModel: ObservableObject {
+public final class SubsonicMultiSourceSearchViewModel: ObservableObject, SubsonicAnnotationObserving {
     /// Per-server soft timeout. Slow servers stop blocking the aggregate.
     public static let defaultTimeout: Duration = .milliseconds(2000)
 
@@ -60,12 +60,21 @@ public final class SubsonicMultiSourceSearchViewModel: ObservableObject {
 
     @Published public private(set) var query = ""
     @Published public private(set) var songs: [SubsonicSongHit] = [] {
-        didSet { self.songsVersion &+= 1 }
+        didSet { self.rebuildRows() }
     }
 
-    /// Moves on every write to `songs`; `SubsonicSongTable` skips its per-row
-    /// walks while the rows version it is given holds (#455).
-    public private(set) var songsVersion = 0
+    /// Decorated rows for `SubsonicSongTable`, owned here rather than mapped
+    /// in the view's body, so the O(n) decoration of a search result set (up
+    /// to 500 hits per server) runs once per change of the hits or the
+    /// annotation overrides instead of once per re-render (#475).
+    @Published private(set) var rows: [SubsonicSongTableRow] = [] {
+        didSet { self.rowsVersion &+= 1 }
+    }
+
+    /// Moves on every write to `rows` via `didSet`, so no path can forget it;
+    /// `SubsonicSongTable` skips its per-row walks while it holds (#455).
+    private(set) var rowsVersion = 0
+
     @Published public private(set) var albums: [SubsonicAlbumHit] = []
     @Published public private(set) var artists: [SubsonicArtistHit] = []
     @Published public private(set) var isSearching = false
@@ -73,15 +82,42 @@ public final class SubsonicMultiSourceSearchViewModel: ObservableObject {
 
     private let dataSource: any SubsonicBrowseDataSource
     private let timeout: Duration
+    /// Held strongly: the coordinator outlives this view model, and its own
+    /// reference back to here is weak.
+    private let annotations: SubsonicAnnotationCoordinator?
     private let log = AppLogger.make(.ui)
     private var currentTask: Task<Void, Never>?
 
     public init(
         dataSource: any SubsonicBrowseDataSource,
-        timeout: Duration = SubsonicMultiSourceSearchViewModel.defaultTimeout
+        timeout: Duration = SubsonicMultiSourceSearchViewModel.defaultTimeout,
+        annotations: SubsonicAnnotationCoordinator? = nil
     ) {
         self.dataSource = dataSource
         self.timeout = timeout
+        self.annotations = annotations
+        annotations?.addObserver(self)
+    }
+
+    // MARK: - Rows
+
+    /// Rebuilds every row from the current hits and overrides. Each hit
+    /// carries its own server, so the rows can span servers.
+    private func rebuildRows() {
+        let annotations = self.annotations
+        self.rows = self.songs.map { hit in
+            SubsonicSongTableRow.make(
+                song: hit.song,
+                serverID: hit.serverID,
+                serverName: hit.serverName,
+                annotations: annotations
+            )
+        }
+    }
+
+    /// A star or rating moved: the stored rows are now stale (#475).
+    public func annotationOverridesDidChange() {
+        self.rebuildRows()
     }
 
     /// Cancels any in-flight search and clears the aggregated lists.

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongTable.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongTable.swift
@@ -33,6 +33,31 @@ struct SubsonicSongTableRow: Identifiable {
         "\(serverID.uuidString)::\(songID)"
     }
 
+    /// Decorates one song, resolving the star and rating against the
+    /// coordinator's optimistic overrides.
+    ///
+    /// Only the row-owning view models call this, once per change of their song
+    /// list, the overrides or the server name. No view builds rows in its
+    /// body: that put an O(n) map on every re-render, including ones caused by
+    /// unrelated state such as a synced lyric line (#475).
+    @MainActor
+    static func make(
+        song: Song,
+        serverID: UUID,
+        serverName: String,
+        annotations: SubsonicAnnotationCoordinator?
+    ) -> Self {
+        Self(
+            song: song,
+            serverID: serverID,
+            serverName: serverName,
+            starred: annotations?.isStarred(songID: song.id, serverStarred: song.starred)
+                ?? (song.starred != nil),
+            rating: annotations?.rating(songID: song.id, serverRating: song.userRating)
+                ?? (song.userRating ?? 0)
+        )
+    }
+
     var title: String {
         self.song.title
     }
@@ -100,11 +125,12 @@ struct SubsonicSongTableActions {
 struct SubsonicSongTable: NSViewRepresentable {
     let rows: [SubsonicSongTableRow]
     /// The owner's counter for `rows` (#455): `updateNSView` walks the rows
-    /// only when this moved since the last apply. Rows are derived in the
-    /// view from a song list and the annotation overrides, so the version
-    /// folds both counters; see `rowsVersion(songs:annotations:)`.
-    /// Deliberately has no default: a caller that left it out would render
-    /// its first rows and then never react to another change (#454).
+    /// only when this moved since the last apply. The rows are stored on a
+    /// view model that rebuilds them when its song list, the annotation
+    /// overrides or the server name change, and this is that model's
+    /// `rowsVersion` (#475). Deliberately has no default: a caller that left
+    /// it out would render its first rows and then never react to another
+    /// change (#454).
     let rowsVersion: Int
     let isLoading: Bool
     let hasMorePages: Bool
@@ -117,13 +143,6 @@ struct SubsonicSongTable: NSViewRepresentable {
     let actions: SubsonicSongTableActions
 
     typealias NSViewType = NSScrollView
-
-    /// The rows version for a table whose rows are derived from a song list
-    /// counter plus the annotation coordinator's override counter. Both only
-    /// ever increase, so their sum moves whenever either input changed.
-    static func rowsVersion(songs: Int, annotations: SubsonicAnnotationCoordinator?) -> Int {
-        songs &+ (annotations?.overridesVersion ?? 0)
-    }
 
     func makeCoordinator() -> SubsonicSongTableCoordinator {
         SubsonicSongTableCoordinator(parent: self)

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongTable.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongTable.swift
@@ -97,6 +97,24 @@ struct SubsonicSongTableRow: Identifiable {
     var coverArtEntityID: String? {
         self.song.coverArt
     }
+
+    // MARK: - Content equality
+
+    /// `true` when every *displayed* value matches `other`.
+    ///
+    /// Row identity is the server plus the song ID, which is what the diffable
+    /// data source keys on and what must stay stable across a reload. The
+    /// table still needs to know when a row's rendered values moved in place,
+    /// a rating or a star above all, so it can reload that one row (#476).
+    /// Every displayed field derives from `song` plus the server pair, so
+    /// comparing those covers the whole row.
+    func hasSameContent(as other: Self) -> Bool {
+        self.song == other.song
+            && self.serverID == other.serverID
+            && self.serverName == other.serverName
+            && self.starred == other.starred
+            && self.rating == other.rating
+    }
 }
 
 // MARK: - Actions bag
@@ -234,8 +252,14 @@ struct SubsonicSongTable: NSViewRepresentable {
 
         case .reconfigure:
             // Same rows, new content (a star or rating moved): refresh the
-            // cell-lookup dictionary that the star and text cells read from.
+            // cell-lookup dictionary that the star and text cells read from,
+            // then reload the rows whose rendered values actually moved. The
+            // star cell repaints itself on click, but the Rating cell is plain
+            // text and used to keep the old value until it was scrolled out
+            // and back (#476).
+            let changed = Self.changedRowIDs(from: coordinator.rowsByID, to: self.rows)
             coordinator.updateRows(self.rows)
+            Self.reload(rows: changed, dataSource: dataSource)
 
         case .structural:
             coordinator.updateRows(self.rows)
@@ -262,6 +286,35 @@ struct SubsonicSongTable: NSViewRepresentable {
         // Once the snapshot reflects the current rows, move the selection onto
         // the now-playing row when it changes.
         coordinator.syncSelectionToNowPlaying(self.nowPlayingRowID)
+    }
+
+    // MARK: Reconfigure
+
+    /// IDs of the rows whose rendered values differ from the ones the
+    /// coordinator is still holding. A row the coordinator does not know is
+    /// not a content change: the structural path owns new rows.
+    static func changedRowIDs(
+        from oldRowsByID: [String: SubsonicSongTableRow],
+        to rows: [SubsonicSongTableRow]
+    ) -> [String] {
+        rows.compactMap { row in
+            guard let old = oldRowsByID[row.id], !old.hasSameContent(as: row) else { return nil }
+            return row.id
+        }
+    }
+
+    /// Reloads the given rows in place, ignoring IDs the snapshot does not
+    /// hold and duplicates. A no-op for an empty list, which is the common
+    /// case: most reconfigure passes move one row.
+    private static func reload(rows changed: [String], dataSource: SubsonicSongDiffableDataSource) {
+        guard !changed.isEmpty else { return }
+        var snapshot = dataSource.snapshot()
+        let existing = Set(snapshot.itemIdentifiers(inSection: 0))
+        var seen = Set<String>()
+        let valid = changed.filter { existing.contains($0) && seen.insert($0).inserted }
+        guard !valid.isEmpty else { return }
+        snapshot.reloadItems(valid)
+        dataSource.apply(snapshot, animatingDifferences: false)
     }
 
     // MARK: Column definitions

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongsView.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongsView.swift
@@ -39,7 +39,9 @@ public struct SubsonicSongsView: View {
             wrappedValue: SubsonicSongsViewModel(
                 serverID: serverID,
                 dataSource: dataSource,
-                cache: library.subsonicMetadataCache
+                cache: library.subsonicMetadataCache,
+                annotations: library.subsonicAnnotations,
+                serverName: library.subsonicServers.first { $0.id == serverID }?.name ?? ""
             )
         )
         // Safe: `subsonicSearch` is always non-nil whenever this view is
@@ -88,6 +90,11 @@ public struct SubsonicSongsView: View {
                 await self.vm.load()
             }
         }
+        // The row owner needs the server's display name, and the sidebar list
+        // it comes from may load, or be renamed, after this view appears.
+        .onChange(of: self.currentServerName, initial: true) { _, name in
+            self.vm.serverName = name
+        }
         .loadErrorAlert(L10n.string("Couldn't load songs"), message: self.$vm.errorMessage)
     }
 
@@ -104,27 +111,9 @@ public struct SubsonicSongsView: View {
         } else if self.vm.songs.isEmpty {
             ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
         } else {
-            let serverName = self.currentServerName
-            let rows = self.vm.songs.map { song in
-                SubsonicSongTableRow(
-                    song: song,
-                    serverID: self.serverID,
-                    serverName: serverName,
-                    starred: self.annotationCoordinator?.isStarred(
-                        songID: song.id,
-                        serverStarred: song.starred
-                    ) ?? (song.starred != nil),
-                    rating: self.annotationCoordinator?.rating(
-                        songID: song.id,
-                        serverRating: song.userRating
-                    ) ?? (song.userRating ?? 0)
-                )
-            }
             SubsonicSongTable(
-                rows: rows,
-                rowsVersion: SubsonicSongTable.rowsVersion(
-                    songs: self.vm.songsVersion, annotations: self.annotationCoordinator
-                ),
+                rows: self.vm.rows,
+                rowsVersion: self.vm.rowsVersion,
                 isLoading: self.vm.isLoading,
                 hasMorePages: self.vm.hasMorePages,
                 coverArtProvider: self.coverArtProvider,
@@ -179,30 +168,13 @@ public struct SubsonicSongsView: View {
                 ContentUnavailableView.search(text: self.library.searchQuery)
             }
         } else {
-            let rows = self.search.songs.map { hit in
-                SubsonicSongTableRow(
-                    song: hit.song,
-                    serverID: hit.serverID,
-                    serverName: hit.serverName,
-                    starred: self.annotationCoordinator?.isStarred(
-                        songID: hit.song.id,
-                        serverStarred: hit.song.starred
-                    ) ?? (hit.song.starred != nil),
-                    rating: self.annotationCoordinator?.rating(
-                        songID: hit.song.id,
-                        serverRating: hit.song.userRating
-                    ) ?? (hit.song.userRating ?? 0)
-                )
-            }
             VStack(spacing: 0) {
                 if !self.search.failedServerNames.isEmpty {
                     SubsonicSearchFailedBanner(serverNames: self.search.failedServerNames)
                 }
                 SubsonicSongTable(
-                    rows: rows,
-                    rowsVersion: SubsonicSongTable.rowsVersion(
-                        songs: self.search.songsVersion, annotations: self.annotationCoordinator
-                    ),
+                    rows: self.search.rows,
+                    rowsVersion: self.search.rowsVersion,
                     isLoading: self.search.isSearching,
                     hasMorePages: false,
                     coverArtProvider: self.coverArtProvider,

--- a/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongsViewModel.swift
+++ b/Modules/UI/Sources/UI/Browse/Subsonic/SubsonicSongsViewModel.swift
@@ -12,24 +12,45 @@ import SwiftUI
 /// repeatedly calls `getRandomSongs` to surface a deep but shuffled sample of
 /// the server's library. "Refresh" reseeds the sample; "Load more" appends.
 @MainActor
-public final class SubsonicSongsViewModel: ObservableObject {
+public final class SubsonicSongsViewModel: ObservableObject, SubsonicAnnotationObserving {
     public static let pageSize = 100
 
     public let serverID: UUID
 
     @Published public private(set) var songs: [Song] = [] {
-        didSet { self.songsVersion &+= 1 }
+        didSet { self.rebuildRows() }
     }
 
-    /// Moves on every write to `songs`; `SubsonicSongTable` skips its per-row
-    /// walks while the rows version it is given holds (#455).
-    public private(set) var songsVersion = 0
+    /// Decorated rows for `SubsonicSongTable`, owned here rather than mapped
+    /// in the view's body, so the O(n) decoration runs once per change of the
+    /// song list, the annotation overrides or the server name instead of once
+    /// per re-render (#475).
+    @Published private(set) var rows: [SubsonicSongTableRow] = [] {
+        didSet { self.rowsVersion &+= 1 }
+    }
+
+    /// Moves on every write to `rows` via `didSet`, so no path can forget it;
+    /// `SubsonicSongTable` skips its per-row walks while it holds (#455).
+    private(set) var rowsVersion = 0
+
+    /// Display name of this server, carried on every row. Set by the view,
+    /// which reads it from the sidebar server list; a rename rebuilds the rows.
+    public var serverName: String {
+        didSet {
+            guard self.serverName != oldValue else { return }
+            self.rebuildRows()
+        }
+    }
+
     @Published public private(set) var isLoading = false
     @Published public private(set) var hasMorePages = true
     @Published public var errorMessage: String?
 
     private let dataSource: any SubsonicBrowseDataSource
     private let cache: (any SubsonicMetadataCaching)?
+    /// Held strongly: the coordinator outlives this view model, and its own
+    /// reference back to here is weak.
+    private let annotations: SubsonicAnnotationCoordinator?
     private let log = AppLogger.make(.ui)
 
     private static let cacheKind = "songs.randomSample"
@@ -38,11 +59,35 @@ public final class SubsonicSongsViewModel: ObservableObject {
     public init(
         serverID: UUID,
         dataSource: any SubsonicBrowseDataSource,
-        cache: (any SubsonicMetadataCaching)? = nil
+        cache: (any SubsonicMetadataCaching)? = nil,
+        annotations: SubsonicAnnotationCoordinator? = nil,
+        serverName: String = ""
     ) {
         self.serverID = serverID
         self.dataSource = dataSource
         self.cache = cache
+        self.annotations = annotations
+        self.serverName = serverName
+        annotations?.addObserver(self)
+    }
+
+    // MARK: - Rows
+
+    /// Rebuilds every row from the current song list and overrides.
+    private func rebuildRows() {
+        let serverID = self.serverID
+        let serverName = self.serverName
+        let annotations = self.annotations
+        self.rows = self.songs.map {
+            SubsonicSongTableRow.make(
+                song: $0, serverID: serverID, serverName: serverName, annotations: annotations
+            )
+        }
+    }
+
+    /// A star or rating moved: the stored rows are now stale (#475).
+    public func annotationOverridesDidChange() {
+        self.rebuildRows()
     }
 
     /// Initial load — populates the random sample once per view lifetime.

--- a/Modules/UI/Sources/UI/ViewModels/LibraryViewModel.swift
+++ b/Modules/UI/Sources/UI/ViewModels/LibraryViewModel.swift
@@ -493,8 +493,13 @@ public final class LibraryViewModel: ObservableObject { // swiftlint:disable:thi
         self.subsonicDataSource = subsonicDataSource
         self.subsonicCoverArtProvider = subsonicCoverArtProvider
         self.subsonicMetadataCache = subsonicMetadataCache
-        self.subsonicSearch = subsonicDataSource.map { SubsonicMultiSourceSearchViewModel(dataSource: $0) }
-        self.subsonicAnnotations = subsonicAnnotationDelivery.map { SubsonicAnnotationCoordinator(delivery: $0) }
+        let subsonicAnnotations = subsonicAnnotationDelivery.map { SubsonicAnnotationCoordinator(delivery: $0) }
+        self.subsonicAnnotations = subsonicAnnotations
+        // The search view model owns its table rows, so it needs the
+        // coordinator to rebuild them when a star or rating moves (#475).
+        self.subsonicSearch = subsonicDataSource.map {
+            SubsonicMultiSourceSearchViewModel(dataSource: $0, annotations: subsonicAnnotations)
+        }
         self.settingsRepo = SettingsRepository(database: database)
         let radioStations = RadioStationRepository(database: database)
         self.radioStations = radioStations

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicAnnotationCoordinatorTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicAnnotationCoordinatorTests.swift
@@ -67,6 +67,26 @@ private final class SpyAnnotationObserver: SubsonicAnnotationObserving {
     }
 }
 
+// MARK: - Haptics isolation
+
+/// Runs `body` with the process-global haptic seam silenced, and restores it.
+///
+/// `Haptics.performPattern` is one closure for the whole process.
+/// `NowPlayingViewModelTests.transportHaptics` installs a recorder into it and
+/// keeps it installed across suspension points, then asserts that no
+/// level-change haptic was performed. A star or rating written by any
+/// concurrently running test lands in that recorder and fails it, so a test
+/// that writes one for some other reason silences the seam around the call.
+/// The swap never suspends, so no other `@MainActor` test can observe it.
+/// A test that is *about* the haptic installs its own recorder instead.
+@MainActor
+func silencingHaptics<T>(_ body: () -> T) -> T {
+    let original = Haptics.performPattern
+    Haptics.performPattern = { _ in }
+    defer { Haptics.performPattern = original }
+    return body()
+}
+
 // MARK: - Tests
 
 @Suite("SubsonicAnnotationCoordinator")
@@ -91,13 +111,19 @@ struct SubsonicAnnotationCoordinatorTests {
         coord.addObserver(observer)
         #expect(observer.changes == 0, "registering is not a change")
 
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        }
         #expect(observer.changes == 1, "a star override is a write")
 
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: true)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: true)
+        }
         #expect(observer.changes == 2, "clearing it is a write too")
 
-        coord.setRating(songID: "s1", serverID: self.serverID, newRating: 4, previousRating: nil)
+        silencingHaptics {
+            coord.setRating(songID: "s1", serverID: self.serverID, newRating: 4, previousRating: nil)
+        }
         #expect(observer.changes == 3, "a rating override is a write")
         await self.waitForCalls(stub, count: 3)
     }
@@ -110,7 +136,9 @@ struct SubsonicAnnotationCoordinatorTests {
         coord.addObserver(observer)
         coord.addObserver(observer)
 
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        }
         #expect(observer.changes == 1, "registering twice must not notify twice")
 
         // A destination that goes away deregisters itself: no teardown call,
@@ -119,7 +147,9 @@ struct SubsonicAnnotationCoordinatorTests {
             let transient = SpyAnnotationObserver()
             coord.addObserver(transient)
         }
-        coord.toggleStar(songID: "s2", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s2", serverID: self.serverID, currentlyStarred: false)
+        }
         #expect(observer.changes == 2)
         await self.waitForCalls(stub, count: 2)
     }
@@ -129,7 +159,9 @@ struct SubsonicAnnotationCoordinatorTests {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
         #expect(coord.isStarred(songID: "s1", serverStarred: nil) == false)
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        }
         #expect(coord.isStarred(songID: "s1", serverStarred: nil) == true)
         await self.waitForCalls(stub, count: 1)
         #expect(stub.calls == [.star(self.serverID, "s1")])
@@ -139,7 +171,9 @@ struct SubsonicAnnotationCoordinatorTests {
     func toggleStarUnstars() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: true)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: true)
+        }
         #expect(coord.isStarred(songID: "s1", serverStarred: Date()) == false)
         await self.waitForCalls(stub, count: 1)
         #expect(stub.calls == [.unstar(self.serverID, "s1")])
@@ -149,7 +183,9 @@ struct SubsonicAnnotationCoordinatorTests {
     func setRatingDispatches() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.setRating(songID: "s1", serverID: self.serverID, newRating: 9, previousRating: nil)
+        silencingHaptics {
+            coord.setRating(songID: "s1", serverID: self.serverID, newRating: 9, previousRating: nil)
+        }
         #expect(coord.rating(songID: "s1", serverRating: nil) == 5)
         await self.waitForCalls(stub, count: 1)
         #expect(stub.calls == [.setRating(self.serverID, "s1", 5)])
@@ -159,7 +195,9 @@ struct SubsonicAnnotationCoordinatorTests {
     func failureRollbackStar() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        }
         #expect(coord.isStarred(songID: "s1", serverStarred: nil) == true)
         stub.emit(SubsonicAnnotationFailure(serverID: self.serverID, songID: "s1", reason: "boom"))
         for _ in 0 ..< 50 {
@@ -175,7 +213,9 @@ struct SubsonicAnnotationCoordinatorTests {
     func failureRollbackRating() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.setRating(songID: "s1", serverID: self.serverID, newRating: 4, previousRating: 2)
+        silencingHaptics {
+            coord.setRating(songID: "s1", serverID: self.serverID, newRating: 4, previousRating: 2)
+        }
         #expect(coord.rating(songID: "s1", serverRating: 2) == 4)
         stub.emit(SubsonicAnnotationFailure(serverID: self.serverID, songID: "s1", reason: "boom"))
         for _ in 0 ..< 50 {
@@ -191,8 +231,10 @@ struct SubsonicAnnotationCoordinatorTests {
     func failureIsolatedToSong() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
-        coord.toggleStar(songID: "s2", serverID: self.serverID, currentlyStarred: false)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+            coord.toggleStar(songID: "s2", serverID: self.serverID, currentlyStarred: false)
+        }
         stub.emit(SubsonicAnnotationFailure(serverID: self.serverID, songID: "s1", reason: "boom"))
         for _ in 0 ..< 50 {
             if coord.isStarred(songID: "s1", serverStarred: nil) == false {
@@ -221,8 +263,10 @@ struct SubsonicAnnotationCoordinatorTests {
     func resetDropsOverrides() {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
-        coord.setRating(songID: "s1", serverID: self.serverID, newRating: 3, previousRating: nil)
+        silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+            coord.setRating(songID: "s1", serverID: self.serverID, newRating: 3, previousRating: nil)
+        }
         coord.reset(songID: "s1")
         #expect(coord.isStarred(songID: "s1", serverStarred: nil) == false)
         #expect(coord.rating(songID: "s1", serverRating: nil) == 0)

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicAnnotationCoordinatorTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicAnnotationCoordinatorTests.swift
@@ -56,6 +56,17 @@ private final class StubAnnotationDelivery: SubsonicAnnotationDelivering, @unche
     }
 }
 
+/// Stands in for a row-owning view model: counts the rebuild calls the
+/// coordinator makes (#475).
+@MainActor
+private final class SpyAnnotationObserver: SubsonicAnnotationObserving {
+    private(set) var changes = 0
+
+    func annotationOverridesDidChange() {
+        self.changes += 1
+    }
+}
+
 // MARK: - Tests
 
 @Suite("SubsonicAnnotationCoordinator")
@@ -72,18 +83,44 @@ struct SubsonicAnnotationCoordinatorTests {
         }
     }
 
-    @Test("every override write moves overridesVersion, so derived table rows get a new version (#455)")
-    func overridesVersionMovesWithOverrides() async {
+    @Test("every override write tells the row owners to rebuild (#475)")
+    func everyOverrideWriteNotifiesObservers() async {
         let stub = StubAnnotationDelivery()
         let coord = SubsonicAnnotationCoordinator(delivery: stub)
-        let fresh = coord.overridesVersion
+        let observer = SpyAnnotationObserver()
+        coord.addObserver(observer)
+        #expect(observer.changes == 0, "registering is not a change")
 
         coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
-        let starred = coord.overridesVersion
-        #expect(starred > fresh, "a star override is a write")
+        #expect(observer.changes == 1, "a star override is a write")
 
         coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: true)
-        #expect(coord.overridesVersion > starred, "clearing it is a write too")
+        #expect(observer.changes == 2, "clearing it is a write too")
+
+        coord.setRating(songID: "s1", serverID: self.serverID, newRating: 4, previousRating: nil)
+        #expect(observer.changes == 3, "a rating override is a write")
+        await self.waitForCalls(stub, count: 3)
+    }
+
+    @Test("an observer is registered once and held weakly")
+    func observerRegistrationIsIdempotentAndWeak() async {
+        let stub = StubAnnotationDelivery()
+        let coord = SubsonicAnnotationCoordinator(delivery: stub)
+        let observer = SpyAnnotationObserver()
+        coord.addObserver(observer)
+        coord.addObserver(observer)
+
+        coord.toggleStar(songID: "s1", serverID: self.serverID, currentlyStarred: false)
+        #expect(observer.changes == 1, "registering twice must not notify twice")
+
+        // A destination that goes away deregisters itself: no teardown call,
+        // and no crash on the next write.
+        do {
+            let transient = SpyAnnotationObserver()
+            coord.addObserver(transient)
+        }
+        coord.toggleStar(songID: "s2", serverID: self.serverID, currentlyStarred: false)
+        #expect(observer.changes == 2)
         await self.waitForCalls(stub, count: 2)
     }
 

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
@@ -852,6 +852,78 @@ struct SubsonicMultiSourceSearchViewModelTests {
     }
 }
 
+// MARK: - Reconfigure diff (#476)
+
+/// A rating set from the context menu lands in the rows as a same-set update,
+/// which the table answers with its `.reconfigure` branch. That branch used to
+/// refresh the cell-lookup dictionary and reload nothing, so the Rating column
+/// kept the old value until the cell was scrolled out and back. It now reloads
+/// exactly the rows whose rendered values moved.
+@Suite("Subsonic song table reconfigure diff")
+@MainActor
+struct SubsonicSongTableReconfigureTests {
+    private let serverID = UUID()
+
+    private func row(_ i: Int, starred: Bool = false, rating: Int = 0) -> SubsonicSongTableRow {
+        SubsonicSongTableRow(
+            song: song(i),
+            serverID: self.serverID,
+            serverName: "Living Room",
+            starred: starred,
+            rating: rating
+        )
+    }
+
+    private func byID(_ rows: [SubsonicSongTableRow]) -> [String: SubsonicSongTableRow] {
+        Dictionary(rows.map { ($0.id, $0) }) { _, new in new }
+    }
+
+    @Test("a rating change reloads exactly its own row")
+    func ratingChangeReloadsItsRow() {
+        let before = [self.row(1), self.row(2), self.row(3)]
+        let after = [self.row(1), self.row(2, rating: 4), self.row(3)]
+
+        let changed = SubsonicSongTable.changedRowIDs(from: self.byID(before), to: after)
+
+        #expect(changed == [after[1].id])
+    }
+
+    @Test("a star change reloads its row")
+    func starChangeReloadsItsRow() {
+        let before = [self.row(1), self.row(2)]
+        let after = [self.row(1, starred: true), self.row(2)]
+
+        let changed = SubsonicSongTable.changedRowIDs(from: self.byID(before), to: after)
+
+        #expect(changed == [after[0].id])
+    }
+
+    @Test("rows with identical content reload nothing")
+    func unchangedRowsReloadNothing() {
+        let before = [self.row(1, starred: true, rating: 3), self.row(2)]
+        let after = [self.row(1, starred: true, rating: 3), self.row(2)]
+
+        #expect(SubsonicSongTable.changedRowIDs(from: self.byID(before), to: after).isEmpty)
+    }
+
+    @Test("a row the table has not seen is left to the structural path")
+    func unknownRowIsNotAContentChange() {
+        let before = [self.row(1)]
+        let after = [self.row(1), self.row(2, rating: 5)]
+
+        #expect(SubsonicSongTable.changedRowIDs(from: self.byID(before), to: after).isEmpty)
+    }
+
+    @Test("content equality covers the values the cells render")
+    func contentEqualityCoversRenderedValues() {
+        let base = self.row(1)
+        #expect(base.hasSameContent(as: self.row(1)))
+        #expect(!base.hasSameContent(as: self.row(1, rating: 1)))
+        #expect(!base.hasSameContent(as: self.row(1, starred: true)))
+        #expect(base.id == self.row(1, rating: 5).id, "a rating never changes row identity")
+    }
+}
+
 // MARK: - Row ownership (#475)
 
 /// Annotation delivery that accepts every write and never reports a failure.

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
@@ -957,21 +957,6 @@ struct SubsonicSongRowOwnershipTests {
         SubsonicAnnotationCoordinator(delivery: SilentAnnotationDelivery())
     }
 
-    /// Runs `body` with the process-global haptic seam silenced.
-    ///
-    /// A star or rating performs a level-change haptic through the one
-    /// `Haptics.performPattern` closure, and the transport-haptics test
-    /// records that closure across suspension points. These tests write
-    /// overrides for their rows, not for the haptic, so their emissions must
-    /// not land in a recorder another test is reading. The swap never
-    /// suspends, so no other @MainActor test can observe it.
-    private func silencingHaptics(_ body: () -> Void) {
-        let original = Haptics.performPattern
-        Haptics.performPattern = { _ in }
-        defer { Haptics.performPattern = original }
-        body()
-    }
-
     private func settle(_ isBusy: @escaping () -> Bool) async {
         for _ in 0 ..< 50 {
             if !isBusy() {
@@ -1006,7 +991,7 @@ struct SubsonicSongRowOwnershipTests {
         let loaded = vm.rowsVersion
         #expect(vm.rows.first?.starred == false)
 
-        self.silencingHaptics {
+        silencingHaptics {
             coord.toggleStar(songID: "s1", serverID: serverID, currentlyStarred: false)
         }
 
@@ -1023,7 +1008,7 @@ struct SubsonicSongRowOwnershipTests {
         let vm = SubsonicSongsViewModel(serverID: serverID, dataSource: stub, annotations: coord)
         await vm.load()
 
-        self.silencingHaptics {
+        silencingHaptics {
             coord.setRating(songID: "s1", serverID: serverID, newRating: 4, previousRating: nil)
         }
 
@@ -1060,7 +1045,7 @@ struct SubsonicSongRowOwnershipTests {
         #expect(vm.rows.map(\.song.id) == ["s1", "s2"])
         let loaded = vm.rowsVersion
 
-        self.silencingHaptics {
+        silencingHaptics {
             coord.setRating(songID: "s2", serverID: serverID, newRating: 5, previousRating: nil)
         }
         #expect(vm.rows.last?.rating == 5)
@@ -1085,7 +1070,7 @@ struct SubsonicSongRowOwnershipTests {
         #expect(vm.rows.map(\.song.id) == ["s1", "s2"])
         let loaded = vm.rowsVersion
 
-        self.silencingHaptics {
+        silencingHaptics {
             coord.toggleStar(songID: "s1", serverID: serverID, currentlyStarred: false)
         }
         #expect(vm.rows.first?.starred == true)
@@ -1106,7 +1091,7 @@ struct SubsonicSongRowOwnershipTests {
         #expect(Set(vm.rows.map(\.serverID)).count == 2, "each row keeps the server it came from")
         let found = vm.rowsVersion
 
-        self.silencingHaptics {
+        silencingHaptics {
             coord.toggleStar(songID: "s1", serverID: vm.songs[0].serverID, currentlyStarred: false)
         }
         #expect(Set(vm.rows.map(\.starred)) == Set([true]), "the override is keyed by song ID, so both rows follow")

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift
@@ -87,12 +87,23 @@ private actor StubBrowseDataSource: SubsonicBrowseDataSource {
         return next
     }
 
+    var artistDetail: ArtistID3?
+    var albumDetail: AlbumID3?
+
+    func seedArtistDetail(_ artist: ArtistID3) {
+        self.artistDetail = artist
+    }
+
+    func seedAlbumDetail(_ album: AlbumID3) {
+        self.albumDetail = album
+    }
+
     func getArtist(serverID: UUID, id: String) async throws -> ArtistID3 {
-        ArtistID3(id: id, name: "Stub")
+        self.artistDetail ?? ArtistID3(id: id, name: "Stub")
     }
 
     func getAlbum(serverID: UUID, id: String) async throws -> AlbumID3 {
-        AlbumID3(id: id, name: "Stub", songCount: 0, duration: 0)
+        self.albumDetail ?? AlbumID3(id: id, name: "Stub", songCount: 0, duration: 0)
     }
 
     // MARK: ADR-035 step 11 — optional destinations
@@ -296,20 +307,22 @@ struct SubsonicSongsViewModelTests {
         #expect(vm.isLoading == false)
     }
 
-    @Test("every write to songs moves songsVersion, so the table can skip unchanged updates (#455)")
-    func songsVersionMovesWithSongs() async {
+    @Test("every write to songs rebuilds the rows and moves rowsVersion (#455, #475)")
+    func rowsVersionMovesWithSongs() async {
         let stub = StubBrowseDataSource()
         // A full first page, or the view model concludes there is no more to load.
         await stub.seedRandomPages([(0 ..< 100).map { song($0) }, [song(100)]])
         let vm = SubsonicSongsViewModel(serverID: serverID, dataSource: stub)
-        let fresh = vm.songsVersion
+        let fresh = vm.rowsVersion
 
         await vm.load()
-        let loaded = vm.songsVersion
+        let loaded = vm.rowsVersion
         #expect(loaded > fresh, "load() writes songs")
+        #expect(vm.rows.count == vm.songs.count, "the rows are the song list, decorated")
 
         await vm.loadMore()
-        #expect(vm.songsVersion > loaded, "loadMore() writes songs again")
+        #expect(vm.rowsVersion > loaded, "loadMore() writes songs again")
+        #expect(vm.rows.count == vm.songs.count)
     }
 
     @Test("loadMore() appends and dedupes by id")
@@ -836,5 +849,195 @@ struct SubsonicMultiSourceSearchViewModelTests {
         #expect(vm.artists.isEmpty)
         #expect(vm.query.isEmpty)
         #expect(vm.isSearching == false)
+    }
+}
+
+// MARK: - Row ownership (#475)
+
+/// Annotation delivery that accepts every write and never reports a failure.
+/// The row-ownership tests care about the optimistic overrides, not delivery.
+private final class SilentAnnotationDelivery: SubsonicAnnotationDelivering, @unchecked Sendable {
+    func annotationFailures() -> AsyncStream<SubsonicAnnotationFailure> {
+        AsyncStream { _ in }
+    }
+
+    func star(serverID _: UUID, songID _: String) async {
+        // Accepted and dropped.
+    }
+
+    func unstar(serverID _: UUID, songID _: String) async {
+        // Accepted and dropped.
+    }
+
+    func setRating(serverID _: UUID, songID _: String, rating _: Int) async {
+        // Accepted and dropped.
+    }
+}
+
+/// The song tables used to map their rows in the view body, so an O(n)
+/// decoration ran on every re-render, including ones caused by unrelated
+/// state. The rows now belong to the view models, which rebuild them when the
+/// song list, the overrides or the server name change, and nothing else (#475).
+@Suite("Subsonic song table row ownership")
+@MainActor
+struct SubsonicSongRowOwnershipTests {
+    private func makeCoordinator() -> SubsonicAnnotationCoordinator {
+        SubsonicAnnotationCoordinator(delivery: SilentAnnotationDelivery())
+    }
+
+    /// Runs `body` with the process-global haptic seam silenced.
+    ///
+    /// A star or rating performs a level-change haptic through the one
+    /// `Haptics.performPattern` closure, and the transport-haptics test
+    /// records that closure across suspension points. These tests write
+    /// overrides for their rows, not for the haptic, so their emissions must
+    /// not land in a recorder another test is reading. The swap never
+    /// suspends, so no other @MainActor test can observe it.
+    private func silencingHaptics(_ body: () -> Void) {
+        let original = Haptics.performPattern
+        Haptics.performPattern = { _ in }
+        defer { Haptics.performPattern = original }
+        body()
+    }
+
+    private func settle(_ isBusy: @escaping () -> Bool) async {
+        for _ in 0 ..< 50 {
+            if !isBusy() {
+                return
+            }
+            try? await Task.sleep(for: .milliseconds(20))
+        }
+    }
+
+    @Test("the songs list owns its rows, tagged with the server they came from")
+    func songsViewModelOwnsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedRandomPages([[song(1), song(2)]])
+        let vm = SubsonicSongsViewModel(
+            serverID: serverID, dataSource: stub, serverName: "Living Room"
+        )
+
+        await vm.load()
+
+        #expect(vm.rows.map(\.song.id) == ["s1", "s2"])
+        #expect(Set(vm.rows.map(\.serverName)) == Set(["Living Room"]))
+        #expect(Set(vm.rows.map(\.serverID)) == Set([serverID]))
+    }
+
+    @Test("a star reaches the stored rows without waiting for a re-render")
+    func starRebuildsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedRandomPages([[song(1), song(2)]])
+        let coord = self.makeCoordinator()
+        let vm = SubsonicSongsViewModel(serverID: serverID, dataSource: stub, annotations: coord)
+        await vm.load()
+        let loaded = vm.rowsVersion
+        #expect(vm.rows.first?.starred == false)
+
+        self.silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: serverID, currentlyStarred: false)
+        }
+
+        #expect(vm.rows.first?.starred == true)
+        #expect(vm.rows.last?.starred == false, "only the starred song changes")
+        #expect(vm.rowsVersion > loaded, "the table must be told the rows moved")
+    }
+
+    @Test("a rating reaches the stored rows")
+    func ratingRebuildsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedRandomPages([[song(1)]])
+        let coord = self.makeCoordinator()
+        let vm = SubsonicSongsViewModel(serverID: serverID, dataSource: stub, annotations: coord)
+        await vm.load()
+
+        self.silencingHaptics {
+            coord.setRating(songID: "s1", serverID: serverID, newRating: 4, previousRating: nil)
+        }
+
+        #expect(vm.rows.first?.rating == 4)
+    }
+
+    @Test("a server rename rebuilds the rows; the same name again does not")
+    func serverRenameRebuildsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedRandomPages([[song(1)]])
+        let vm = SubsonicSongsViewModel(serverID: serverID, dataSource: stub, serverName: "Attic")
+        await vm.load()
+
+        vm.serverName = "Cellar"
+        #expect(Set(vm.rows.map(\.serverName)) == Set(["Cellar"]))
+
+        let renamed = vm.rowsVersion
+        vm.serverName = "Cellar"
+        #expect(vm.rowsVersion == renamed, "an identical name is not a change")
+    }
+
+    @Test("album detail rows come from the album's songs and follow the overrides")
+    func albumDetailOwnsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedAlbumDetail(
+            AlbumID3(id: "a1", name: "Album 1", songCount: 2, duration: 400, song: [song(1), song(2)])
+        )
+        let coord = self.makeCoordinator()
+        let vm = SubsonicAlbumDetailViewModel(
+            serverID: serverID, albumID: "a1", dataSource: stub, annotations: coord
+        )
+
+        await vm.load()
+        #expect(vm.rows.map(\.song.id) == ["s1", "s2"])
+        let loaded = vm.rowsVersion
+
+        self.silencingHaptics {
+            coord.setRating(songID: "s2", serverID: serverID, newRating: 5, previousRating: nil)
+        }
+        #expect(vm.rows.last?.rating == 5)
+        #expect(vm.rowsVersion > loaded)
+    }
+
+    @Test("artist detail rows come from the flattened tracks and follow the overrides")
+    func artistDetailOwnsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedArtistDetail(ArtistID3(id: "ar1", name: "Artist", album: [album(1)]))
+        await stub.seedAlbumDetail(
+            AlbumID3(id: "a1", name: "Album 1", songCount: 2, duration: 400, song: [song(1), song(2)])
+        )
+        let coord = self.makeCoordinator()
+        let vm = SubsonicArtistDetailViewModel(
+            serverID: serverID, artistID: "ar1", dataSource: stub, annotations: coord
+        )
+
+        await vm.load()
+        // The albums fan out into a detached task; the tracks land after it.
+        await self.settle { vm.rows.isEmpty }
+        #expect(vm.rows.map(\.song.id) == ["s1", "s2"])
+        let loaded = vm.rowsVersion
+
+        self.silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: serverID, currentlyStarred: false)
+        }
+        #expect(vm.rows.first?.starred == true)
+        #expect(vm.rowsVersion > loaded)
+    }
+
+    @Test("search rows span servers and follow the overrides")
+    func searchOwnsRows() async {
+        let stub = StubBrowseDataSource()
+        await stub.seedSearchResult(makeSearchResult(songs: ["s1"]))
+        let coord = self.makeCoordinator()
+        let vm = SubsonicMultiSourceSearchViewModel(dataSource: stub, annotations: coord)
+
+        vm.search(query: "hi", servers: [sidebarServer("A"), sidebarServer("B")])
+        await self.settle { vm.isSearching }
+
+        #expect(Set(vm.rows.map(\.serverName)) == Set(["A", "B"]))
+        #expect(Set(vm.rows.map(\.serverID)).count == 2, "each row keeps the server it came from")
+        let found = vm.rowsVersion
+
+        self.silencingHaptics {
+            coord.toggleStar(songID: "s1", serverID: vm.songs[0].serverID, currentlyStarred: false)
+        }
+        #expect(Set(vm.rows.map(\.starred)) == Set([true]), "the override is keyed by song ID, so both rows follow")
+        #expect(vm.rowsVersion > found)
     }
 }

--- a/Modules/UI/Tests/UITests/ViewModelTests/SubsonicSongNowPlayingSelectionTests.swift
+++ b/Modules/UI/Tests/UITests/ViewModelTests/SubsonicSongNowPlayingSelectionTests.swift
@@ -144,8 +144,43 @@ struct SubsonicSongNowPlayingWiringTests {
         ] {
             let src = try self.source(rel)
             #expect(
-                src.contains("rowsVersion: SubsonicSongTable.rowsVersion("),
-                "\(rel) must fold its song counter and the annotation counter into the table's rows version"
+                src.contains("rowsVersion: self.vm.rowsVersion") || src.contains("rowsVersion: self.search.rowsVersion"),
+                "\(rel) must take the rows version from the view model that owns the rows"
+            )
+        }
+    }
+
+    @Test("No Subsonic view builds table rows in its body (#475)")
+    func viewsDoNotDecorateRowsInBody() throws {
+        // The album and artist files carry their view model alongside the
+        // view, so `SubsonicSongTableRow.make` legitimately appears in them;
+        // what must not appear anywhere outside the table's own file is the
+        // memberwise init a view body used to map every song through.
+        for rel in [
+            "Browse/Subsonic/SubsonicSongsView.swift",
+            "Browse/Subsonic/SubsonicAlbumDetailView.swift",
+            "Browse/Subsonic/SubsonicArtistDetailView.swift",
+        ] {
+            let src = try self.source(rel)
+            #expect(
+                !src.contains("SubsonicSongTableRow("),
+                "\(rel) must not map songs into rows: that runs on every re-render, including unrelated ones"
+            )
+            #expect(
+                src.contains("rows: self.vm.rows") || src.contains("rows: self.search.rows"),
+                "\(rel) must hand the table the rows its view model stores"
+            )
+        }
+        for rel in [
+            "Browse/Subsonic/SubsonicSongsViewModel.swift",
+            "Browse/Subsonic/SubsonicAlbumDetailView.swift",
+            "Browse/Subsonic/SubsonicArtistDetailView.swift",
+            "Browse/Subsonic/SubsonicMultiSourceSearchViewModel.swift",
+        ] {
+            let src = try self.source(rel)
+            #expect(
+                src.contains("func annotationOverridesDidChange()"),
+                "\(rel) must rebuild its stored rows when a star or rating moves"
             )
         }
     }

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -263,9 +263,9 @@ Never gate on a piped grep, whose status is grep's. And in a test file that uses
 
 **Problem:** `NowPlayingViewModelTests.transportHaptics` fails in a full `make test-ui` run with "Expectation failed: !patterns.contains(.levelChange)", and passes when run alone or with a few suites.
 
-**Rule:** a test that writes a Subsonic star or rating while it is suspended must silence the haptic seam around the call: save `Haptics.performPattern`, set it to `{ _ in }`, call, restore, with no `await` in between.
+**Rule:** a test that writes a Subsonic star or rating for any reason other than testing the haptic wraps the call in `silencingHaptics { … }` (`SubsonicAnnotationCoordinatorTests.swift`). A test that is about the haptic installs its own recorder instead.
 
-**Why:** `Haptics.performPattern` is one process-global closure. `transportHaptics` installs a recorder and keeps it installed across suspension points, so a `.levelChange` performed by any concurrently running test lands in its array. A swap with no suspension point is invisible to other `@MainActor` tests. `SubsonicAnnotationCoordinatorTests` still writes overrides unsilenced, which leaves the same flake reachable.
+**Why:** `Haptics.performPattern` is one process-global closure. `transportHaptics` installs a recorder and keeps it installed across suspension points, so a `.levelChange` performed by any concurrently running test lands in its array. The helper swaps the seam and restores it with no suspension point in between, which makes the swap invisible to other `@MainActor` tests.
 
 **Canonical file:** `Modules/UI/Sources/UI/Common/Haptics.swift`
 

--- a/docs/GOTCHAS.md
+++ b/docs/GOTCHAS.md
@@ -245,6 +245,30 @@ Never gate on a piped grep, whose status is grep's. And in a test file that uses
 
 **Canonical file:** Makefile targets under `make test-<module>`
 
+### Never put `allSatisfy` with a key path inside `#expect`
+
+**Problem:** a test compiles under `swift test` but the Xcode bundle fails to build with `call can throw, but it is not marked with 'try'` pointing at `$0.allSatisfy($1)` inside a macro expansion. Writing it as a closure fixes it, and then `make format` puts the key path back and the build breaks again.
+
+**Rule:** do not call a `rethrows` predicate method (`allSatisfy`, `contains(where:)`, `filter`) as the outermost expression of a `#expect`. Compare sets or hoist the result:
+
+```swift
+#expect(Set(rows.map(\.starred)) == Set([true]))
+```
+
+**Why:** the `#expect` macro decomposes the outermost boolean call into `$0.allSatisfy($1)` to build its failure message, and that rewrite loses the `rethrows` inference for a key-path argument. SwiftFormat's `preferKeyPath` rule rewrites `allSatisfy { $0.x }` into `allSatisfy(\.x)`, so a closure is not a stable workaround. `map(\.x)` is fine because it is not the outermost call.
+
+**Canonical file:** `Modules/UI/Tests/UITests/ViewModelTests/SubsonicBrowseViewModelTests.swift`
+
+### A test that stars a song can fail the transport-haptics test
+
+**Problem:** `NowPlayingViewModelTests.transportHaptics` fails in a full `make test-ui` run with "Expectation failed: !patterns.contains(.levelChange)", and passes when run alone or with a few suites.
+
+**Rule:** a test that writes a Subsonic star or rating while it is suspended must silence the haptic seam around the call: save `Haptics.performPattern`, set it to `{ _ in }`, call, restore, with no `await` in between.
+
+**Why:** `Haptics.performPattern` is one process-global closure. `transportHaptics` installs a recorder and keeps it installed across suspension points, so a `.levelChange` performed by any concurrently running test lands in its array. A swap with no suspension point is invisible to other `@MainActor` tests. `SubsonicAnnotationCoordinatorTests` still writes overrides unsilenced, which leaves the same flake reachable.
+
+**Canonical file:** `Modules/UI/Sources/UI/Common/Haptics.swift`
+
 ### Diagnosing a frozen debug run
 
 **Problem:** the app is unresponsive and it is not obvious whether it crashed, hung, or is paused.


### PR DESCRIPTION
Closes #475.
Closes #476.
Closes #483.

The four `SubsonicSongTable` call sites mapped every song into a decorated row in the view body, so an O(n) walk ran on every re-render of the view, including ones caused by unrelated state such as a synced lyric line. #455 stopped the table walking unchanged rows; this stops the map above it.

The rows now belong to the view models, the way `TracksViewModel` owns its rows: each stores a rows array plus a `rowsVersion` that moves on every write, and rebuilds only when its song list, the annotation overrides or the server name change. The per-list counters (`songsVersion`, `tracksVersion`, `albumVersion`) and the coordinator's `overridesVersion` are gone with the derivation they fed.

An override change now reaches the rows directly. `SubsonicAnnotationCoordinator` keeps a weak list of row owners and tells them to rebuild, because it reaches the views through the environment, which does not subscribe to `objectWillChange`. And the table's reconfigure branch reloads the rows whose rendered values moved, so a rating set from the context menu repaints instead of waiting to be scrolled out and back (#476).

#483 is not code in this PR. Its fix, the `do`/`catch` around the `SubsonicStreamCache` init in `App/BocanApp.swift`, landed in PR #499 (commit `72d1d218`), which did not name the issue. This PR closes it.

## Slice review

1. What observers, timers, or views will re-run as a result, and how often?
   Answer: `SubsonicAnnotationCoordinator` calls `annotationOverridesDidChange()` on every write to either override map (`SubsonicAnnotationCoordinator.swift:35,41,61`), so once per star or rating the user sets, plus up to twice per rollback (`handleFailure` writes both maps). Each registered view model rebuilds its whole rows array and publishes it (`SubsonicSongsViewModel.swift:77,89`), which re-renders the view observing it: at most the open destination's model plus the app-lifetime search model, so two or three rebuilds per action. Against that, the per-re-render rebuild is gone: the table's `updateNSView` still runs whenever the parent re-renders but does nothing when `rowsVersion` holds (`SubsonicSongTable.swift:250`). New per-action work is one content diff and one `reloadItems` apply for the changed rows (`SubsonicSongTable.swift:296,309`). The three views also gained `.onChange(of: currentServerName, initial: true)`, a one-`String` comparison per re-render that writes only on a difference, and the model's `serverName` `didSet` guards on value change again.
2. What is the complexity in terms of library size?
   Answer: n is the rows in one list, bounded by the 100-row page (Songs), the album or artist track count, or the 500-per-server search cap. Before: O(n) decoration per re-render of the view, two dictionary lookups per row. After: O(1) per re-render, O(n) per change of the song list, the overrides or the server name. A star or rating costs one O(n) rebuild plus one O(n) diff with an O(1) lookup per row, and reloads k rows, k normally 1. Search merge is O(n) per server merged, as it was. No instrument trace was taken: the change removes work from the hot path and the one added walk is bounded by 500 and runs on a user action. Local library tables are untouched.
3. What did you create that needs cancelling or invalidating, and who owns it?
   Answer: the coordinator's observer list. Entries are weak boxes (`SubsonicAnnotationCoordinator.swift:50`), pruned on registration and on every notify (`:57,62`), so a destination's view model deregisters by deallocating and no teardown call exists to forget. The coordinator owns the list; `LibraryViewModel` owns the coordinator (`LibraryViewModel.swift:456`). The view models hold the coordinator strongly and the back reference is weak, so there is no cycle. Covered by "an observer is registered once and held weakly". One caveat: the array only shrinks when something registers or notifies, so browsing many detail pages without ever starring leaves that many empty boxes, eight bytes each. No tasks, timers or subscriptions were created.
4. Which error paths propagate, recover, or fail loudly?
   Answer: no new error path. Building a row cannot fail and the load paths are unchanged. One existing recovery now actually reaches the screen: when the retry queue reports `annotationFailed`, `handleFailure` restores the previous override, which rebuilds the rows and reloads that row, so a failed star or rating visibly reverts instead of leaving the optimistic value on screen until something else redrew the window.
5. What existing type or utility did you check before adding a new one?
   Answer: `TracksViewModel.rows` / `rowsVersion` (`TracksViewModel.swift:25`) gave the ownership shape, copied rather than invented. `TrackRow.hasSameContent(as:)` (`TrackRow.swift:135`) and `TrackTable.reconfigureChangedRows` (`TrackTable.swift:305`) gave the content-diff and reload shape, including the dedupe and exists filter. `TableUpdatePlan` was already generic over both tables and is reused unchanged, with no new plan type. `SubsonicSongTableRow.id(serverID:songID:)` stays the identity, and the new `make` sits beside it instead of a separate builder type. Combine on the coordinator's `objectWillChange` was considered and rejected: the coordinator arrives through the environment, which does not subscribe to it, and it fires before the value lands.
6. What did you stub, simplify, or leave incomplete?
   Answer: the rebuild is whole-array, not per-song, so a star on a song outside a given list still rebuilds that list and bumps its version, costing one map and one diff that finds nothing; deliberate, given the bounded sizes. `serverName` is pushed in from the view rather than observed in the model, which is honest for what it is: the three single-server tables never display it, since the Source column only appears for search results, where the name comes from the hit. Nothing was run against a live Subsonic server in this session.
7. What is the strongest argument that this is the wrong approach?
   Answer: that the observer list re-implements what SwiftUI observation already does, and the real fix is to put the coordinator where views observe it rather than in the environment, which would delete `SubsonicAnnotationObserving` and let the rows stay derived. The counter is that observing it that way re-renders every Subsonic view on every override write, which is the invalidation width #452 and #455 were narrowing, and the derived rows would go back to being rebuilt per render. The second-strongest: the rows array is now duplicated state that can drift from the song list, and the `didSet` on the song list is the only thing keeping them in step.

**What a user, or another module, would notice is different** (behaviour, not files):
- A Subsonic song list no longer rebuilds its rows when something unrelated in the window changes, such as a synced lyric line advancing.
- A rating set from the song table's context menu appears in the Rating column straight away, instead of keeping the old value until the row was scrolled out and back.
- A star or rating whose write to the server fails now visibly reverts in the list.
- Nothing changes for the local library tables, and no other module sees a behaviour change. The `UI` module's surface changed (a new observer protocol, new defaulted init parameters, the removed counters), but `App` only constructs `LibraryViewModel`, which is source-compatible.

**Tried against a full-size library** (thousands of tracks, not a test fixture): no, because every path touched is the Subsonic browse path, which needs a live server rather than a local library, and the maintainer runs the app himself. The worst case is bounded by the page size of 100 and the search cap of 500 per server.

**Things noticed but not fixed here**: none. The one finding, that any test writing a star or rating could fail `NowPlayingViewModelTests.transportHaptics` through the process-global `Haptics.performPattern` seam, is fixed in this PR instead of filed (`test(ui): keep a star or rating out of another test's haptic recorder`), and the rule is in `docs/GOTCHAS.md`.
